### PR TITLE
Feature/36 disable worker

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/ui/config/AppConfigScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/config/AppConfigScreen.kt
@@ -470,7 +470,7 @@ private fun WorkScheduleStatusCard(
                         WorkInfo.State.SUCCEEDED -> "Completed successfully"
                         WorkInfo.State.FAILED -> "Failed"
                         WorkInfo.State.BLOCKED -> "Waiting for conditions"
-                        WorkInfo.State.CANCELLED -> "Cancelled"
+                        WorkInfo.State.CANCELLED -> "Cancelled\nValidate and continue to reschedule"
                         null -> "Unknown"
                     }
 
@@ -579,7 +579,7 @@ private fun WorkScheduleStatusCard(
                                 modifier = Modifier.size(20.dp),
                             )
                             Spacer(modifier = Modifier.width(8.dp))
-                            Text("Cancel Scheduled Refresh")
+                            Text("Cancel Periodic Refresh Job")
                         }
                     }
                 }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `AppConfigScreen.kt` file, focusing on improving UI layout, adding functionality for work cancellation, and refining date/time formatting. Below is a summary of the most important changes grouped by theme:

### UI Enhancements:
* Adjusted padding in the `AppConfigContent` composable to use `horizontal = 32.dp` for a more consistent layout.

### Work Management Improvements:
* Added a coroutine scope (`rememberCoroutineScope`) in `WorkScheduleStatusCard` to enable asynchronous operations, such as canceling scheduled work.
* Introduced a button to cancel periodic work directly from the UI when the work is in `ENQUEUED`, `RUNNING`, or `BLOCKED` states. The button uses a red theme to indicate its critical action.

### Status and Formatting Enhancements:
* Enhanced the `CANCELLED` work state message to include additional guidance: "Cancelled\nValidate and continue to reschedule."
* Improved the date/time formatting logic by ensuring `nextScheduleTimeMillis` is validated against `Long.MAX_VALUE` and simplifying the use of `DateTimeFormatter` and `Instant`.

These changes collectively improve the user experience, provide better feedback on work status, and add functionality for managing scheduled tasks.