### PR TITLE
Fake api flag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "dev.hossain.trmnl"
         minSdk = 30
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
 
         // Read key or other properties from local.properties
         val localProperties =

--- a/app/src/debug/java/dev/hossain/trmnl/data/DevConfig.kt
+++ b/app/src/debug/java/dev/hossain/trmnl/data/DevConfig.kt
@@ -1,0 +1,12 @@
+package dev.hossain.trmnl.data
+
+/**
+ * Development configuration for the TRMNL app.
+ */
+object DevConfig {
+    /**
+     * Fake API response for local development and testing purposes.
+     * In debug builds, we use fake API responses.
+     */
+    const val FAKE_API_RESPONSE = true
+}

--- a/app/src/main/java/dev/hossain/trmnl/data/AppConfig.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/AppConfig.kt
@@ -8,9 +8,4 @@ object AppConfig {
      * Default display refresh rate in case the server does not provide one.
      */
     const val DEFAULT_REFRESH_RATE_SEC: Long = 7_200L // 2 hours
-
-    /**
-     * Fake API response for local development and testing purposes.
-     */
-    const val FAKE_API_RESPONSE = false
 }

--- a/app/src/main/java/dev/hossain/trmnl/data/AppConfig.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/AppConfig.kt
@@ -8,4 +8,9 @@ object AppConfig {
      * Default display refresh rate in case the server does not provide one.
      */
     const val DEFAULT_REFRESH_RATE_SEC: Long = 7_200L // 2 hours
+
+    /**
+     * Fake API response for local development and testing purposes.
+     */
+    const val FAKE_API_RESPONSE = false
 }

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -1,7 +1,7 @@
 package dev.hossain.trmnl.data
 
 import com.squareup.anvil.annotations.optional.SingleIn
-import dev.hossain.trmnl.BuildConfig
+import dev.hossain.trmnl.data.AppConfig.FAKE_API_RESPONSE
 import dev.hossain.trmnl.di.AppScope
 import dev.hossain.trmnl.network.TrmnlApiService
 import timber.log.Timber
@@ -9,6 +9,9 @@ import javax.inject.Inject
 
 /**
  * Repository class responsible for fetching and mapping display data.
+ *
+ * ⚠️ NOTE: By default, [FAKE_API_RESPONSE] is set to `true` and it will
+ * not make any network calls. Set it to `false` to enable real API calls.
  */
 @SingleIn(AppScope::class)
 class TrmnlDisplayRepository
@@ -25,7 +28,7 @@ class TrmnlDisplayRepository
          * @return A [TrmnlDisplayInfo] object containing the display data.
          */
         suspend fun getDisplayData(accessToken: String): TrmnlDisplayInfo {
-            if (BuildConfig.DEBUG) {
+            if (FAKE_API_RESPONSE) {
                 // Avoid using real API in debug mode
                 return fakeTrmnlDisplayInfo()
             }
@@ -65,6 +68,8 @@ class TrmnlDisplayRepository
 
         /**
          * Generates fake display info for debugging purposes without wasting an API request.
+         *
+         * ℹ️ This is only used when [FAKE_API_RESPONSE] is set to `true`.
          */
         private suspend fun fakeTrmnlDisplayInfo(): TrmnlDisplayInfo {
             Timber.d("DEBUG: Using mock data for display info")

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -10,8 +10,9 @@ import javax.inject.Inject
 /**
  * Repository class responsible for fetching and mapping display data.
  *
- * ⚠️ NOTE: By default, [FAKE_API_RESPONSE] is set to `true` and it will
- * not make any network calls. Set it to `false` to enable real API calls.
+ * ⚠️ NOTE: [FAKE_API_RESPONSE] is set to `true` in debug builds, meaning it will
+ * use mock data and avoid network calls. In release builds, it is set to `false`
+ * to enable real API calls.
  */
 @SingleIn(AppScope::class)
 class TrmnlDisplayRepository

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -1,7 +1,7 @@
 package dev.hossain.trmnl.data
 
 import com.squareup.anvil.annotations.optional.SingleIn
-import dev.hossain.trmnl.data.AppConfig.FAKE_API_RESPONSE
+import dev.hossain.trmnl.data.DevConfig.FAKE_API_RESPONSE
 import dev.hossain.trmnl.di.AppScope
 import dev.hossain.trmnl.network.TrmnlApiService
 import timber.log.Timber

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -13,6 +13,8 @@ import javax.inject.Inject
  * ⚠️ NOTE: [FAKE_API_RESPONSE] is set to `true` in debug builds, meaning it will
  * use mock data and avoid network calls. In release builds, it is set to `false`
  * to enable real API calls.
+ *
+ * You can override this behavior by updating [DevConfig.FAKE_API_RESPONSE] for local development.
  */
 @SingleIn(AppScope::class)
 class TrmnlDisplayRepository

--- a/app/src/release/java/dev/hossain/trmnl/data/DevConfig.kt
+++ b/app/src/release/java/dev/hossain/trmnl/data/DevConfig.kt
@@ -1,0 +1,12 @@
+package dev.hossain.trmnl.data
+
+/**
+ * Development configuration for the TRMNL app.
+ */
+object DevConfig {
+    /**
+     * Fake API response for local development and testing purposes.
+     * In release builds, we use real API responses.
+     */
+    const val FAKE_API_RESPONSE = false
+}


### PR DESCRIPTION
Fixes #54

This pull request introduces several updates to the TRMNL app, including versioning changes, a new development configuration for managing fake API responses, and updates to the repository logic to support this configuration. Below is a summary of the most important changes:

### Versioning Updates:
* Updated `versionCode` to `2` and `versionName` to `1.1` in `app/build.gradle.kts` to reflect a new version of the app.

### Development Configuration:
* Added a new `DevConfig` object in both `debug` and `release` build variants to manage the `FAKE_API_RESPONSE` flag, enabling fake API responses in debug builds (`true`) and real API responses in release builds (`false`). (`app/src/debug/java/dev/hossain/trmnl/data/DevConfig.kt` [[1]](diffhunk://#diff-69737046161bc0f93a0ee8b5f42039faa9efe86a52d3cd59c3334ccbab5095e8R1-R12) `app/src/release/java/dev/hossain/trmnl/data/DevConfig.kt` [[2]](diffhunk://#diff-bed9eaa909e05bfdf11a319e06957662fa0364190d758b49b554d0e136906802R1-R12))

### Repository Logic Updates:
* Replaced the use of `BuildConfig.DEBUG` with `DevConfig.FAKE_API_RESPONSE` in `TrmnlDisplayRepository` to determine whether to use fake API responses. [[1]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517L4-R14) [[2]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517L28-R31)
* Updated documentation in `TrmnlDisplayRepository` to clarify the behavior of `FAKE_API_RESPONSE` and its impact on API calls and fake data generation.