### PR TITLE
[ADDED] Worker code cleanup

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/trmnl/MainActivity.kt
@@ -90,72 +90,51 @@ class MainActivity
          * 4. Logs work status and errors
          */
         private fun listenForWorkUpdates() {
-            // Listen for work results
-            WorkManager
-                .getInstance(context)
-                .getWorkInfosForUniqueWorkLiveData(IMAGE_REFRESH_PERIODIC_WORK_NAME)
-                .observe(this) { workInfos ->
-                    workInfos.forEach { workInfo ->
-                        if (workInfo.state == WorkInfo.State.SUCCEEDED) {
-                            Timber.d("Periodic work succeeded: $workInfo")
-                            val newImageUrl =
-                                workInfo.outputData.getString(
-                                    TrmnlImageRefreshWorker.KEY_NEW_IMAGE_URL,
-                                )
+            val workManager = WorkManager.getInstance(context)
 
-                            if (newImageUrl != null) {
-                                Timber.d("New image URL from periodic work: $newImageUrl")
-                                // Update the image URL via the manager
+            // Create a reusable observer function
+            fun observeWork(workName: String) {
+                workManager.getWorkInfosForUniqueWorkLiveData(workName).observe(this) { workInfos ->
+                    workInfos.forEach { workInfo ->
+                        when (workInfo.state) {
+                            WorkInfo.State.SUCCEEDED -> {
+                                Timber.d("$workName work succeeded: $workInfo")
+                                val newImageUrl =
+                                    workInfo.outputData.getString(
+                                        TrmnlImageRefreshWorker.KEY_NEW_IMAGE_URL,
+                                    )
+
+                                if (newImageUrl != null) {
+                                    Timber.d("New image URL from $workName: $newImageUrl")
+                                    trmnlImageUpdateManager.updateImage(
+                                        ImageMetadata(
+                                            url = newImageUrl,
+                                            timestamp = System.currentTimeMillis(),
+                                            refreshRateSecs = null,
+                                        ),
+                                    )
+                                }
+                            }
+                            WorkInfo.State.FAILED -> {
+                                val error = workInfo.outputData.getString(TrmnlImageRefreshWorker.KEY_ERROR_MESSAGE)
+                                Timber.e("$workName work failed: $error")
                                 trmnlImageUpdateManager.updateImage(
                                     ImageMetadata(
-                                        url = newImageUrl,
+                                        url = "",
                                         timestamp = System.currentTimeMillis(),
                                         refreshRateSecs = null,
+                                        errorMessage = error,
                                     ),
                                 )
                             }
+                            else -> { /* No action needed for other states */ }
                         }
                     }
                 }
+            }
 
-            // Also listen for one-time work results
-            WorkManager
-                .getInstance(context)
-                .getWorkInfosForUniqueWorkLiveData(IMAGE_REFRESH_ONETIME_WORK_NAME)
-                .observe(this) { workInfos ->
-                    // ⚠️ DEV NOTE: Previously ran work info is broadcasted here,
-                    // so it may result in inconsistent behavior where it remembers last result.
-                    workInfos.forEach { workInfo ->
-                        if (workInfo.state == WorkInfo.State.SUCCEEDED) {
-                            Timber.d("One-time work succeeded: $workInfo")
-                            val newImageUrl =
-                                workInfo.outputData.getString(
-                                    TrmnlImageRefreshWorker.KEY_NEW_IMAGE_URL,
-                                )
-
-                            if (newImageUrl != null) {
-                                Timber.d("New image URL from one-time work: $newImageUrl")
-                                trmnlImageUpdateManager.updateImage(
-                                    ImageMetadata(
-                                        url = newImageUrl,
-                                        timestamp = System.currentTimeMillis(),
-                                        refreshRateSecs = null,
-                                    ),
-                                )
-                            }
-                        } else if (workInfo.state == WorkInfo.State.FAILED) {
-                            val error = workInfo.outputData.getString(TrmnlImageRefreshWorker.KEY_ERROR_MESSAGE)
-                            Timber.e("One-time work failed: $error")
-                            trmnlImageUpdateManager.updateImage(
-                                ImageMetadata(
-                                    url = "",
-                                    timestamp = System.currentTimeMillis(),
-                                    refreshRateSecs = null,
-                                    errorMessage = error,
-                                ),
-                            )
-                        }
-                    }
-                }
+            // Observe both work types
+            observeWork(IMAGE_REFRESH_PERIODIC_WORK_NAME)
+            observeWork(IMAGE_REFRESH_ONETIME_WORK_NAME)
         }
     }

--- a/app/src/main/java/dev/hossain/trmnl/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/trmnl/MainActivity.kt
@@ -152,7 +152,7 @@ class MainActivity
                                 )
                             }
                         } else if (workInfo.state == WorkInfo.State.FAILED) {
-                            val error = workInfo.outputData.getString(TrmnlImageRefreshWorker.KEY_ERROR)
+                            val error = workInfo.outputData.getString(TrmnlImageRefreshWorker.KEY_ERROR_MESSAGE)
                             Timber.e("One-time work failed: $error")
                             trmnlImageUpdateManager.updateImage(
                                 ImageMetadata(

--- a/app/src/main/java/dev/hossain/trmnl/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/trmnl/MainActivity.kt
@@ -98,29 +98,21 @@ class MainActivity
                     workInfos.forEach { workInfo ->
                         if (workInfo.state == WorkInfo.State.SUCCEEDED) {
                             Timber.d("Periodic work succeeded: $workInfo")
-                            val hasNewImage =
-                                workInfo.outputData.getBoolean(
-                                    TrmnlImageRefreshWorker.KEY_HAS_NEW_IMAGE,
-                                    false,
+                            val newImageUrl =
+                                workInfo.outputData.getString(
+                                    TrmnlImageRefreshWorker.KEY_NEW_IMAGE_URL,
                                 )
 
-                            if (hasNewImage) {
-                                val newImageUrl =
-                                    workInfo.outputData.getString(
-                                        TrmnlImageRefreshWorker.KEY_NEW_IMAGE_URL,
-                                    )
-
-                                if (newImageUrl != null) {
-                                    Timber.d("New image URL from periodic work: $newImageUrl")
-                                    // Update the image URL via the manager
-                                    trmnlImageUpdateManager.updateImage(
-                                        ImageMetadata(
-                                            url = newImageUrl,
-                                            timestamp = System.currentTimeMillis(),
-                                            refreshRateSecs = null,
-                                        ),
-                                    )
-                                }
+                            if (newImageUrl != null) {
+                                Timber.d("New image URL from periodic work: $newImageUrl")
+                                // Update the image URL via the manager
+                                trmnlImageUpdateManager.updateImage(
+                                    ImageMetadata(
+                                        url = newImageUrl,
+                                        timestamp = System.currentTimeMillis(),
+                                        refreshRateSecs = null,
+                                    ),
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -76,7 +76,7 @@ class TrmnlDisplayRepository
          */
         private suspend fun fakeTrmnlDisplayInfo(): TrmnlDisplayInfo {
             Timber.d("DEBUG: Using mock data for display info")
-            val mockImageUrl = "https://picsum.photos/300/200?grayscale"
+            val mockImageUrl = "https://picsum.photos/300/200?grayscale&time=${System.currentTimeMillis()}"
             val mockRefreshRate = 600L
 
             // Save mock data to the data store

--- a/app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt
@@ -57,8 +57,8 @@ import dev.hossain.trmnl.R
 import dev.hossain.trmnl.data.ImageMetadataStore
 import dev.hossain.trmnl.di.AppScope
 import dev.hossain.trmnl.ui.FullScreenMode
-import dev.hossain.trmnl.ui.settings.AppSettingsScreen
 import dev.hossain.trmnl.ui.refreshlog.DisplayRefreshLogScreen
+import dev.hossain.trmnl.ui.settings.AppSettingsScreen
 import dev.hossain.trmnl.util.CoilRequestUtils
 import dev.hossain.trmnl.util.TokenManager
 import dev.hossain.trmnl.work.TrmnlImageUpdateManager

--- a/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
@@ -70,8 +70,8 @@ import dev.hossain.trmnl.data.AppConfig.DEFAULT_REFRESH_RATE_SEC
 import dev.hossain.trmnl.data.ImageMetadata
 import dev.hossain.trmnl.data.TrmnlDisplayRepository
 import dev.hossain.trmnl.di.AppScope
-import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult
 import dev.hossain.trmnl.ui.display.TrmnlMirrorDisplayScreen
+import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult
 import dev.hossain.trmnl.util.CoilRequestUtils
 import dev.hossain.trmnl.util.TokenManager
 import dev.hossain.trmnl.work.TrmnlImageUpdateManager

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
@@ -1,6 +1,7 @@
 package dev.hossain.trmnl.work
 
 import android.content.Context
+import androidx.annotation.Keep
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
@@ -10,6 +11,8 @@ import dev.hossain.trmnl.data.log.TrmnlRefreshLogManager
 import dev.hossain.trmnl.di.WorkerModule
 import dev.hossain.trmnl.ui.display.TrmnlMirrorDisplayScreen
 import dev.hossain.trmnl.util.TokenManager
+import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshResult.FAILURE
+import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshResult.SUCCESS
 import kotlinx.coroutines.flow.firstOrNull
 import timber.log.Timber
 import javax.inject.Inject
@@ -37,8 +40,13 @@ class TrmnlImageRefreshWorker(
 
         const val KEY_REFRESH_RESULT = "refresh_result"
         const val KEY_NEW_IMAGE_URL = "new_image_url"
-        const val KEY_ERROR = "error"
-        const val KEY_HAS_NEW_IMAGE = "has_new_image"
+        const val KEY_ERROR_MESSAGE = "error_message"
+    }
+
+    @Keep
+    enum class RefreshResult {
+        SUCCESS,
+        FAILURE,
     }
 
     override suspend fun doWork(): Result {
@@ -52,8 +60,8 @@ class TrmnlImageRefreshWorker(
                 refreshLogManager.addFailureLog("No access token found")
                 return Result.failure(
                     workDataOf(
-                        KEY_REFRESH_RESULT to "failure",
-                        KEY_ERROR to "No access token found",
+                        KEY_REFRESH_RESULT to FAILURE.name,
+                        KEY_ERROR_MESSAGE to "No access token found",
                     ),
                 )
             }
@@ -67,8 +75,8 @@ class TrmnlImageRefreshWorker(
                 refreshLogManager.addFailureLog(response.error ?: "Unknown server error")
                 return Result.failure(
                     workDataOf(
-                        KEY_REFRESH_RESULT to "failure",
-                        KEY_ERROR to (response.error ?: "Unknown server error"),
+                        KEY_REFRESH_RESULT to FAILURE.name,
+                        KEY_ERROR_MESSAGE to (response.error ?: "Unknown server error"),
                     ),
                 )
             }
@@ -79,8 +87,8 @@ class TrmnlImageRefreshWorker(
                 refreshLogManager.addFailureLog("No image URL provided in response")
                 return Result.failure(
                     workDataOf(
-                        KEY_REFRESH_RESULT to "failure",
-                        KEY_ERROR to "No image URL provided in response",
+                        KEY_REFRESH_RESULT to FAILURE.name,
+                        KEY_ERROR_MESSAGE to "No image URL provided in response",
                     ),
                 )
             }
@@ -103,9 +111,8 @@ class TrmnlImageRefreshWorker(
             Timber.tag(TAG).i("Image refresh successful, new URL: ${response.imageUrl}")
             return Result.success(
                 workDataOf(
-                    KEY_REFRESH_RESULT to "success",
+                    KEY_REFRESH_RESULT to SUCCESS.name,
                     KEY_NEW_IMAGE_URL to response.imageUrl,
-                    KEY_HAS_NEW_IMAGE to true,
                 ),
             )
         } catch (e: Exception) {
@@ -113,8 +120,8 @@ class TrmnlImageRefreshWorker(
             refreshLogManager.addFailureLog(e.message ?: "Unknown error during refresh")
             return Result.failure(
                 workDataOf(
-                    KEY_REFRESH_RESULT to "failure",
-                    KEY_ERROR to (e.message ?: "Unknown error during refresh"),
+                    KEY_REFRESH_RESULT to FAILURE.name,
+                    KEY_ERROR_MESSAGE to (e.message ?: "Unknown error during refresh"),
                 ),
             )
         }

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
@@ -11,8 +11,8 @@ import dev.hossain.trmnl.data.log.TrmnlRefreshLogManager
 import dev.hossain.trmnl.di.WorkerModule
 import dev.hossain.trmnl.ui.display.TrmnlMirrorDisplayScreen
 import dev.hossain.trmnl.util.TokenManager
-import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshResult.FAILURE
-import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshResult.SUCCESS
+import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshWorkResult.FAILURE
+import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshWorkResult.SUCCESS
 import kotlinx.coroutines.flow.firstOrNull
 import timber.log.Timber
 import javax.inject.Inject
@@ -44,7 +44,7 @@ class TrmnlImageRefreshWorker(
     }
 
     @Keep
-    enum class RefreshResult {
+    enum class RefreshWorkResult {
         SUCCESS,
         FAILURE,
     }


### PR DESCRIPTION
This pull request refactors work update handling in `MainActivity` and improves consistency in error handling within `TrmnlImageRefreshWorker`. It also includes minor import reordering and annotation additions. Below are the key changes grouped by theme:

### Refactoring Work Update Handling
* Consolidated repetitive `WorkManager` observer logic in `MainActivity` into a reusable `observeWork` function, simplifying the code and reducing duplication. This function now handles both periodic and one-time work updates. [[1]](diffhunk://#diff-3bdc8487b194b1bf551baca415c1dd99ea9013ddfba7567268a5227257091101L93-R108) [[2]](diffhunk://#diff-3bdc8487b194b1bf551baca415c1dd99ea9013ddfba7567268a5227257091101L154-R120) [[3]](diffhunk://#diff-3bdc8487b194b1bf551baca415c1dd99ea9013ddfba7567268a5227257091101R130-R140)

### Improved Error Handling in `TrmnlImageRefreshWorker`
* Replaced `KEY_ERROR` with `KEY_ERROR_MESSAGE` for clearer naming and added a `@Keep` annotation to the new `RefreshWorkResult` enum. This enum (`SUCCESS` and `FAILURE`) replaces string literals for refresh results, improving type safety and readability. [[1]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL40-R49) [[2]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL55-R64) [[3]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL70-R79) [[4]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL82-R91) [[5]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL106-R124)

### Minor Code Improvements
* Reordered imports in `TrmnlMirrorDisplayScreen.kt` and `AppSettingsScreen.kt` to follow a consistent structure. [[1]](diffhunk://#diff-24d6d54ed9c96801768d0eb4a71fdb30941a75ef5d53548cb5d0c9827dbb1878L60-R61) [[2]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L73-R74)
* Added the `@Keep` annotation to `TrmnlImageRefreshWorker` to ensure the `RefreshWorkResult` enum is not removed by code shrinking tools.