### PR TITLE
[FIXED] Potential fix for periodic update for no SUCCEED state.

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageUpdateManager.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageUpdateManager.kt
@@ -24,12 +24,18 @@ class TrmnlImageUpdateManager
         val imageUpdateFlow: StateFlow<ImageMetadata?> = _imageUpdateFlow.asStateFlow()
 
         /**
-         * Updates the image URL and notifies observers through the flow
+         * Updates the image URL and notifies observers through the flow.
+         * Only accepts updates with newer timestamps than the current image.
          * @param imageMetadata The new image URL with additional metadata
          */
         fun updateImage(imageMetadata: ImageMetadata) {
-            Timber.d("Updating image URL in TrmnlImageUpdateManager: $imageMetadata")
-            _imageUpdateFlow.value = imageMetadata
+            val currentImageMetadata = _imageUpdateFlow.value
+            if (currentImageMetadata == null || imageMetadata.timestamp > currentImageMetadata.timestamp) {
+                Timber.d("Updating image URL in TrmnlImageUpdateManager: $imageMetadata")
+                _imageUpdateFlow.value = imageMetadata
+            } else {
+                Timber.d("Discarded older image update: $imageMetadata")
+            }
         }
 
         /**


### PR DESCRIPTION
Despine gemini's confirmation that it should be there https://github.com/hossain-khan/android-trmnl-display/pull/62#issuecomment-2817242399


This pull request enhances the functionality of the `TrmnlImageRefreshWorker` class to address potential issues with periodic work not updating correctly and improves the `TrmnlImageUpdateManager` to handle image updates more robustly. Key changes include the addition of a new dependency, the implementation of a workaround for periodic work, and safeguards for image updates.

### Enhancements to `TrmnlImageRefreshWorker`:

* Added a new dependency, `TrmnlImageUpdateManager`, to manage image updates more effectively. (`[[1]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cR39)`, `[[2]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cR171)`, `[[3]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cR184)`)
* Introduced a new method, `conditionallyUpdateImageForPeriodicWork`, to handle a potential bug where periodic work does not update correctly. This method checks if the image URL has changed and updates it accordingly. (`[app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.ktR136-R157](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cR136-R157)`)
* Integrated the `conditionallyUpdateImageForPeriodicWork` method into the worker's execution flow to ensure periodic work updates are handled. (`[app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.ktR114-R116](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cR114-R116)`)

### Improvements to `TrmnlImageUpdateManager`:

* Enhanced the `updateImage` method to discard updates with older timestamps, ensuring only newer image metadata is applied. (`[app/src/main/java/dev/hossain/trmnl/work/TrmnlImageUpdateManager.ktL27-R38](diffhunk://#diff-6d202ba3000170d4abb246c05f81da8b966fbb8c7e43c0c7cb21595cb27ea5a7L27-R38)`)