### PR TITLE
[UPDATE] Use image name in the refresh log

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayInfo.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayInfo.kt
@@ -9,6 +9,7 @@ import dev.hossain.trmnl.data.AppConfig.DEFAULT_REFRESH_RATE_SEC
 data class TrmnlDisplayInfo(
     val status: Int,
     val imageUrl: String,
+    val imageName: String,
     val error: String? = null,
     val refreshRateSecs: Long? = DEFAULT_REFRESH_RATE_SEC,
 )

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -43,6 +43,7 @@ class TrmnlDisplayRepository
                 TrmnlDisplayInfo(
                     status = response.status,
                     imageUrl = response.imageUrl ?: "",
+                    imageName = response.imageName ?: "",
                     error = response.error,
                     refreshRateSecs = response.refreshRate,
                 )
@@ -85,6 +86,7 @@ class TrmnlDisplayRepository
             return TrmnlDisplayInfo(
                 status = 0,
                 imageUrl = mockImageUrl,
+                imageName = "Mock Image",
                 error = null,
                 refreshRateSecs = mockRefreshRate,
             )

--- a/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLog.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLog.kt
@@ -8,6 +8,7 @@ import java.time.Instant
 data class TrmnlRefreshLog(
     @Json(name = "timestamp") val timestamp: Long,
     @Json(name = "imageUrl") val imageUrl: String?,
+    @Json(name = "imageName") val imageName: String?,
     @Json(name = "refreshRateSeconds") val refreshRateSeconds: Long?,
     @Json(name = "success") val success: Boolean,
     @Json(name = "error") val error: String? = null,
@@ -15,11 +16,13 @@ data class TrmnlRefreshLog(
     companion object {
         fun createSuccess(
             imageUrl: String,
+            imageName: String,
             refreshRateSeconds: Long?,
         ): TrmnlRefreshLog =
             TrmnlRefreshLog(
                 timestamp = Instant.now().toEpochMilli(),
                 imageUrl = imageUrl,
+                imageName = imageName,
                 refreshRateSeconds = refreshRateSeconds,
                 success = true,
             )
@@ -28,6 +31,7 @@ data class TrmnlRefreshLog(
             TrmnlRefreshLog(
                 timestamp = Instant.now().toEpochMilli(),
                 imageUrl = null,
+                imageName = null,
                 refreshRateSeconds = null,
                 success = false,
                 error = error,

--- a/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLogManager.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLogManager.kt
@@ -31,9 +31,10 @@ class TrmnlRefreshLogManager
 
         suspend fun addSuccessLog(
             imageUrl: String,
+            imageName: String,
             refreshRateSeconds: Long?,
         ) {
-            addLog(TrmnlRefreshLog.createSuccess(imageUrl, refreshRateSeconds))
+            addLog(TrmnlRefreshLog.createSuccess(imageUrl, imageName, refreshRateSeconds))
         }
 
         suspend fun addFailureLog(error: String) {

--- a/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
@@ -277,12 +277,12 @@ private fun LogItem(
             ) {
                 Text(
                     text = formattedDate,
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyLarge,
                 )
 
                 Text(
                     text = if (log.success) "✅ Success" else "❌ Failed",
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyLarge,
                     color =
                         if (log.success) {
                             MaterialTheme.colorScheme.primary
@@ -298,11 +298,11 @@ private fun LogItem(
                 Text(
                     text = "Image Name:",
                     fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodyLarge,
                 )
                 Text(
                     text = log.imageName ?: "N/A",
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -314,7 +314,7 @@ private fun LogItem(
                         } else {
                             "Refresh Rate: ${log.refreshRateSeconds ?: "N/A"} seconds"
                         },
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 8.dp),
                 )
             } else {

--- a/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
@@ -19,8 +19,8 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -268,7 +268,7 @@ private fun LogItem(
             modifier = Modifier.padding(16.dp),
         ) {
             // Format timestamp
-            val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+            val dateFormat = SimpleDateFormat("MMM dd, yyyy hh:mm:ss a", Locale.getDefault())
             val formattedDate = dateFormat.format(Date(log.timestamp))
 
             Row(
@@ -292,7 +292,7 @@ private fun LogItem(
                 )
             }
 
-            Divider(modifier = Modifier.padding(vertical = 8.dp))
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
             if (log.success) {
                 Text(
@@ -308,7 +308,12 @@ private fun LogItem(
                 )
 
                 Text(
-                    text = "Refresh Rate: ${log.refreshRateSeconds ?: "N/A"} seconds",
+                    text =
+                        if (log.refreshRateSeconds != null && log.refreshRateSeconds > 60) {
+                            "Refresh Rate: ${log.refreshRateSeconds / 60} minutes"
+                        } else {
+                            "Refresh Rate: ${log.refreshRateSeconds ?: "N/A"} seconds"
+                        },
                     style = MaterialTheme.typography.bodySmall,
                     modifier = Modifier.padding(top = 8.dp),
                 )

--- a/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
@@ -152,6 +152,7 @@ class DisplayRefreshLogPresenter
                                 activityLogManager.addLog(
                                     TrmnlRefreshLog.createSuccess(
                                         imageUrl = "https://debug.example.com/image.png",
+                                        imageName = "test-image.png",
                                         refreshRateSeconds = 300L,
                                     ),
                                 )
@@ -295,12 +296,12 @@ private fun LogItem(
 
             if (log.success) {
                 Text(
-                    text = "Image URL:",
+                    text = "Image Name:",
                     fontWeight = FontWeight.Bold,
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Text(
-                    text = log.imageUrl ?: "N/A",
+                    text = log.imageName ?: "N/A",
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
@@ -97,7 +97,7 @@ class TrmnlImageRefreshWorker(
             }
 
             // ✅ Log success and update image
-            refreshLogManager.addSuccessLog(response.imageUrl, response.refreshRateSecs)
+            refreshLogManager.addSuccessLog(response.imageUrl, response.imageName, response.refreshRateSecs)
 
             // Check if we should adapt refresh rate
             val refreshRate = response.refreshRateSecs


### PR DESCRIPTION
Fixes #76

This pull request introduces the `imageName` property across multiple components to enhance logging and display functionality, along with updates to the UI for better readability. Below is a breakdown of the most important changes:

### Addition of `imageName` Property:

* `TrmnlDisplayInfo` and `TrmnlRefreshLog` data classes were updated to include the `imageName` property, which is used to store the name of the image associated with a log or display entry. (`[[1]](diffhunk://#diff-08193b4f5ee9e29f6551202dee21f107dcb12dc3491f3b13472e4247dd0e009dR12)`, `[[2]](diffhunk://#diff-a4ce323846ccd295419b1720f521a52aeeb4d03332377cf475e9c1496984abdfR11-R25)`)
* `TrmnlDisplayRepository` now populates the `imageName` field when creating `TrmnlDisplayInfo` objects, including mock data. (`[[1]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517R46)`, `[[2]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517R89)`)
* The `TrmnlRefreshLogManager` and `TrmnlImageRefreshWorker` were updated to handle `imageName` when logging success events. (`[[1]](diffhunk://#diff-41f56dc2799c2995546e4c22bc856dd28aaa00f3fe08d26fb056d75f47591e70R34-R37)`, `[[2]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL100-R100)`)

### UI Enhancements in `DisplayRefreshLogScreen`:

* Updated the timestamp format in log entries to a more user-friendly style (e.g., "MMM dd, yyyy hh:mm:ss a"). (`[app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.ktL270-R271](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0L270-R271)`)
* Changed typography styles for better readability in log entries, using `bodyLarge` for text elements. (`[app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.ktL279-R285](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0L279-R285)`)
* Replaced `Divider` with `HorizontalDivider` for visual consistency. (`[[1]](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0L22-R23)`, `[[2]](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0L294-R317)`)
* Updated log display to show `imageName` instead of `imageUrl` for successful logs and improved the display of refresh rates (e.g., converting seconds to minutes when appropriate). (`[app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.ktL294-R317](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0L294-R317)`)