### PR TITLE
[ADDED] 1 min extra wait for periodic refresh job

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/data/AppConfig.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/AppConfig.kt
@@ -8,10 +8,4 @@ object AppConfig {
      * Default display refresh rate in case the server does not provide one.
      */
     const val DEFAULT_REFRESH_INTERVAL_SEC: Long = 7_200L // 2 hours
-
-    /**
-     * When loading current image of the TRMNL, we add this delay before fetching
-     * the image allowing the server to render the image and save it in cloud.
-     */
-    const val EXTRA_REFRESH_WAIT_TIME_SEC: Long = 60L // 60 seconds
 }

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt
@@ -43,7 +43,20 @@ class TrmnlWorkScheduler
             internal const val IMAGE_REFRESH_ONETIME_WORK_NAME = "trmnl_image_refresh_work_onetime"
             internal const val IMAGE_REFRESH_ONETIME_WORK_TAG = "trmnl_image_refresh_work_onetime_tag"
 
+            /**
+             * Minimum interval for periodic work in minutes.
+             * This is the minimum interval required by WorkManager for periodic work.
+             *
+             * - https://developer.android.com/reference/androidx/work/PeriodicWorkRequest
+             * - https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work
+             */
             private const val WORK_MANAGER_MINIMUM_INTERVAL_MINUTES = 15L
+
+            /**
+             * When loading current image of the TRMNL, we add this delay before fetching
+             * the image allowing the server to render the image and save it in cloud.
+             */
+            private const val EXTRA_REFRESH_WAIT_TIME_SEC: Long = 60L // 60 seconds
         }
 
         /**
@@ -69,10 +82,11 @@ class TrmnlWorkScheduler
                 Timber.d("No existing work found, will create new work")
             }
 
-            // Convert seconds to minutes and ensure minimum interval
-            val intervalMinutes = (intervalSeconds / 60).coerceAtLeast(WORK_MANAGER_MINIMUM_INTERVAL_MINUTES)
+            // Add extra wait time to interval and convert seconds to minutes
+            val adjustedIntervalSeconds = intervalSeconds + EXTRA_REFRESH_WAIT_TIME_SEC
+            val intervalMinutes = (adjustedIntervalSeconds / 60).coerceAtLeast(WORK_MANAGER_MINIMUM_INTERVAL_MINUTES)
 
-            Timber.d("Scheduling work: $intervalSeconds seconds → $intervalMinutes minutes")
+            Timber.d("Scheduling work: $intervalSeconds seconds + $EXTRA_REFRESH_WAIT_TIME_SEC seconds → $intervalMinutes minutes")
 
             if (tokenManager.hasTokenSync().not()) {
                 Timber.w("Token not set, skipping image refresh work scheduling")


### PR DESCRIPTION
This pull request refactors the handling of the `EXTRA_REFRESH_WAIT_TIME_SEC` constant and adjusts the logic for scheduling work intervals in the `TrmnlWorkScheduler` class. The constant is moved from `AppConfig` to `TrmnlWorkScheduler`, where it is more relevant, and the scheduling logic now includes this extra wait time when calculating intervals.

### Refactoring of constants:
* Removed `EXTRA_REFRESH_WAIT_TIME_SEC` from `AppConfig` as it is no longer used globally and moved it to `TrmnlWorkScheduler` for local usage. (`app/src/main/java/dev/hossain/trmnl/data/AppConfig.kt`, [app/src/main/java/dev/hossain/trmnl/data/AppConfig.ktL11-L16](diffhunk://#diff-f12b84e7377faf14190051f5a083d5dd1e97568ba64e13da5beeeb9ab55c9ee4L11-L16))  
* Added `EXTRA_REFRESH_WAIT_TIME_SEC` as a private constant in `TrmnlWorkScheduler` to encapsulate its usage within the class. (`app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt`, [app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.ktR46-R59](diffhunk://#diff-756e71d44003929122168506f15a3d5f93fe3df7e65d0ffcc3fe869d9e87951eR46-R59))

### Scheduling logic updates:
* Updated the interval calculation in `TrmnlWorkScheduler` to include `EXTRA_REFRESH_WAIT_TIME_SEC` before converting seconds to minutes. This ensures the wait time is accounted for in the scheduling logic. (`app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt`, [app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.ktL72-R89](diffhunk://#diff-756e71d44003929122168506f15a3d5f93fe3df7e65d0ffcc3fe869d9e87951eL72-R89))  
* Enhanced logging to reflect the inclusion of `EXTRA_REFRESH_WAIT_TIME_SEC` in the interval calculation for better traceability. (`app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt`, [app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.ktL72-R89](diffhunk://#diff-756e71d44003929122168506f15a3d5f93fe3df7e65d0ffcc3fe869d9e87951eL72-R89))