### PR TITLE
[ADDED] Image refresh job type in the log for better tracking

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLog.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLog.kt
@@ -12,12 +12,14 @@ data class TrmnlRefreshLog(
     @Json(name = "refreshRateSeconds") val refreshIntervalSeconds: Long?,
     @Json(name = "success") val success: Boolean,
     @Json(name = "error") val error: String? = null,
+    @Json(name = "refreshWorkType") val imageRefreshWorkType: String? = null,
 ) {
     companion object {
         fun createSuccess(
             imageUrl: String,
             imageName: String,
             refreshIntervalSeconds: Long?,
+            imageRefreshWorkType: String?,
         ): TrmnlRefreshLog =
             TrmnlRefreshLog(
                 timestamp = Instant.now().toEpochMilli(),
@@ -25,6 +27,7 @@ data class TrmnlRefreshLog(
                 imageName = imageName,
                 refreshIntervalSeconds = refreshIntervalSeconds,
                 success = true,
+                imageRefreshWorkType = imageRefreshWorkType,
             )
 
         fun createFailure(error: String): TrmnlRefreshLog =
@@ -35,6 +38,7 @@ data class TrmnlRefreshLog(
                 refreshIntervalSeconds = null,
                 success = false,
                 error = error,
+                imageRefreshWorkType = null,
             )
     }
 }

--- a/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLogManager.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLogManager.kt
@@ -33,8 +33,9 @@ class TrmnlRefreshLogManager
             imageUrl: String,
             imageName: String,
             refreshIntervalSeconds: Long?,
+            imageRefreshWorkType: String?,
         ) {
-            addLog(TrmnlRefreshLog.createSuccess(imageUrl, imageName, refreshIntervalSeconds))
+            addLog(TrmnlRefreshLog.createSuccess(imageUrl, imageName, refreshIntervalSeconds, imageRefreshWorkType))
         }
 
         suspend fun addFailureLog(error: String) {

--- a/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -320,6 +321,7 @@ private fun LogItem(
                 Text(
                     text = log.imageName ?: "N/A",
                     style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = FontFamily.Monospace,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )

--- a/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
@@ -51,6 +51,7 @@ import dev.hossain.trmnl.data.log.TrmnlRefreshLog
 import dev.hossain.trmnl.data.log.TrmnlRefreshLogManager
 import dev.hossain.trmnl.di.AppScope
 import dev.hossain.trmnl.util.getTimeElapsedString
+import dev.hossain.trmnl.work.RefreshWorkType
 import dev.hossain.trmnl.work.TrmnlWorkScheduler
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -156,6 +157,7 @@ class DisplayRefreshLogPresenter
                                         imageUrl = "https://debug.example.com/image.png",
                                         imageName = "test-image.png",
                                         refreshIntervalSeconds = 300L,
+                                        imageRefreshWorkType = RefreshWorkType.ONE_TIME.name,
                                     ),
                                 )
                             }
@@ -332,6 +334,15 @@ private fun LogItem(
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 8.dp),
                 )
+
+                // Add work type display
+                if (log.imageRefreshWorkType != null) {
+                    Text(
+                        text = "Worker Type: ${log.imageRefreshWorkType}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
             } else {
                 Text(
                     text = "Error:",
@@ -344,6 +355,15 @@ private fun LogItem(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )
+
+                // Add work type display for error logs too
+                if (log.imageRefreshWorkType != null) {
+                    Text(
+                        text = "Worker Type: ${log.imageRefreshWorkType}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
@@ -335,10 +335,15 @@ private fun LogItem(
                     modifier = Modifier.padding(top = 8.dp),
                 )
 
-                // Add work type display
                 if (log.imageRefreshWorkType != null) {
                     Text(
-                        text = "Worker Type: ${log.imageRefreshWorkType}",
+                        text = "Refresh Job Type: ${
+                            when (log.imageRefreshWorkType) {
+                                RefreshWorkType.ONE_TIME.name -> "Manual One-time Refresh"
+                                RefreshWorkType.PERIODIC.name -> "Automatic Scheduled Refresh"
+                                else -> "Unknown (${log.imageRefreshWorkType})"
+                            }
+                        }",
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(top = 8.dp),
                     )
@@ -355,15 +360,6 @@ private fun LogItem(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )
-
-                // Add work type display for error logs too
-                if (log.imageRefreshWorkType != null) {
-                    Text(
-                        text = "Worker Type: ${log.imageRefreshWorkType}",
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/dev/hossain/trmnl/work/RefreshWorkResult.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/RefreshWorkResult.kt
@@ -1,0 +1,12 @@
+package dev.hossain.trmnl.work
+
+import androidx.annotation.Keep
+
+/**
+ * Enum class to represent the result of the refresh work by the [TrmnlImageRefreshWorker].
+ */
+@Keep
+enum class RefreshWorkResult {
+    SUCCESS,
+    FAILURE,
+}

--- a/app/src/main/java/dev/hossain/trmnl/work/RefreshWorkType.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/RefreshWorkType.kt
@@ -1,0 +1,21 @@
+package dev.hossain.trmnl.work
+
+import androidx.annotation.Keep
+import dev.hossain.trmnl.data.TrmnlDisplayInfo
+
+/**
+ * Enum class to represent the type of refresh work.
+ */
+@Keep
+enum class RefreshWorkType {
+    /**
+     * Onetime worker request is made by user manually at any time.
+     */
+    ONE_TIME,
+
+    /**
+     * Periodic worker request scheduled by user and time is provided by API server.
+     * @see TrmnlDisplayInfo.refreshIntervalSeconds
+     */
+    PERIODIC,
+}

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
@@ -44,10 +44,19 @@ class TrmnlImageRefreshWorker(
         const val KEY_REFRESH_RESULT = "refresh_result"
         const val KEY_NEW_IMAGE_URL = "new_image_url"
         const val KEY_ERROR_MESSAGE = "error_message"
+        const val PARAM_REFRESH_WORK_TYPE = "refresh_work_type"
+        const val PARAM_LOAD_NEXT_PLAYLIST_DISPLAY_IMAGE = "load_next_playlist_image"
     }
 
     override suspend fun doWork(): Result {
         Timber.tag(TAG).d("Starting image refresh work ($tags)")
+
+        // Get the work type from the input data
+        val workTypeValue = inputData.getString(PARAM_REFRESH_WORK_TYPE) ?: RefreshWorkType.ONE_TIME.name
+        val loadNextPluginImage = inputData.getBoolean(PARAM_LOAD_NEXT_PLAYLIST_DISPLAY_IMAGE, false)
+
+        Timber.tag(TAG).d("Work type: $workTypeValue, loadNextPluginImage: $loadNextPluginImage")
+
         // Get current token
         val token = tokenManager.accessTokenFlow.firstOrNull()
 
@@ -90,7 +99,7 @@ class TrmnlImageRefreshWorker(
         }
 
         // ✅ Log success and update image
-        refreshLogManager.addSuccessLog(response.imageUrl, response.imageName, response.refreshIntervalSeconds)
+        refreshLogManager.addSuccessLog(response.imageUrl, response.imageName, response.refreshIntervalSeconds, workTypeValue)
 
         // Check if we should adapt refresh rate
         val refreshRate = response.refreshIntervalSeconds

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
@@ -1,7 +1,6 @@
 package dev.hossain.trmnl.work
 
 import android.content.Context
-import androidx.annotation.Keep
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
@@ -13,8 +12,8 @@ import dev.hossain.trmnl.ui.display.TrmnlMirrorDisplayScreen
 import dev.hossain.trmnl.util.TokenManager
 import dev.hossain.trmnl.util.isHttpError
 import dev.hossain.trmnl.util.isHttpOk
-import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshWorkResult.FAILURE
-import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.RefreshWorkResult.SUCCESS
+import dev.hossain.trmnl.work.RefreshWorkResult.FAILURE
+import dev.hossain.trmnl.work.RefreshWorkResult.SUCCESS
 import dev.hossain.trmnl.work.TrmnlWorkScheduler.Companion.IMAGE_REFRESH_PERIODIC_WORK_TAG
 import kotlinx.coroutines.flow.firstOrNull
 import timber.log.Timber
@@ -45,12 +44,6 @@ class TrmnlImageRefreshWorker(
         const val KEY_REFRESH_RESULT = "refresh_result"
         const val KEY_NEW_IMAGE_URL = "new_image_url"
         const val KEY_ERROR_MESSAGE = "error_message"
-    }
-
-    @Keep
-    enum class RefreshWorkResult {
-        SUCCESS,
-        FAILURE,
     }
 
     override suspend fun doWork(): Result {

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt
@@ -13,10 +13,13 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkQuery
 import androidx.work.WorkRequest
+import androidx.work.workDataOf
 import com.squareup.anvil.annotations.optional.SingleIn
 import dev.hossain.trmnl.di.AppScope
 import dev.hossain.trmnl.di.ApplicationContext
 import dev.hossain.trmnl.util.TokenManager
+import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.Companion.PARAM_LOAD_NEXT_PLAYLIST_DISPLAY_IMAGE
+import dev.hossain.trmnl.work.TrmnlImageRefreshWorker.Companion.PARAM_REFRESH_WORK_TYPE
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
@@ -110,6 +113,10 @@ class TrmnlWorkScheduler
                         BackoffPolicy.EXPONENTIAL,
                         WorkRequest.DEFAULT_BACKOFF_DELAY_MILLIS,
                         TimeUnit.MILLISECONDS,
+                    ).setInputData(
+                        workDataOf(
+                            PARAM_REFRESH_WORK_TYPE to RefreshWorkType.PERIODIC.name,
+                        ),
                     ).addTag(IMAGE_REFRESH_PERIODIC_WORK_TAG)
                     .build()
 
@@ -121,9 +128,9 @@ class TrmnlWorkScheduler
         }
 
         /**
-         * Start a one-time image refresh work immediately
+         * Start a one-time image refresh work immediately with option to load next playlist item image.
          */
-        fun startOneTimeImageRefreshWork() {
+        fun startOneTimeImageRefreshWork(loadNextPlaylistImage: Boolean = false) {
             Timber.d("Starting one-time image refresh work")
 
             if (tokenManager.hasTokenSync().not()) {
@@ -144,6 +151,11 @@ class TrmnlWorkScheduler
                         BackoffPolicy.EXPONENTIAL,
                         WorkRequest.DEFAULT_BACKOFF_DELAY_MILLIS,
                         TimeUnit.MILLISECONDS,
+                    ).setInputData(
+                        workDataOf(
+                            PARAM_REFRESH_WORK_TYPE to RefreshWorkType.ONE_TIME.name,
+                            PARAM_LOAD_NEXT_PLAYLIST_DISPLAY_IMAGE to loadNextPlaylistImage,
+                        ),
                     ).addTag(IMAGE_REFRESH_ONETIME_WORK_TAG)
                     .build()
 


### PR DESCRIPTION
Fixes #102 

This pull request introduces support for differentiating between one-time and periodic refresh work types in the terminal refresh logging and scheduling system. It also enhances the user interface to display the type of refresh work and improves code maintainability by modularizing enums for work types and results.

### Enhancements to refresh logging and work management:
* Added a new `imageRefreshWorkType` property to the `TrmnlRefreshLog` data class to log the type of refresh work (one-time or periodic). Updated related methods (`createSuccess` and `createFailure`) to handle this property. (`app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLog.kt`, [[1]](diffhunk://#diff-a4ce323846ccd295419b1720f521a52aeeb4d03332377cf475e9c1496984abdfR15-R30) [[2]](diffhunk://#diff-a4ce323846ccd295419b1720f521a52aeeb4d03332377cf475e9c1496984abdfR41)
* Updated `TrmnlRefreshLogManager` to pass the `imageRefreshWorkType` when creating success logs. (`app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLogManager.kt`, [app/src/main/java/dev/hossain/trmnl/data/log/TrmnlRefreshLogManager.ktR36-R38](diffhunk://#diff-41f56dc2799c2995546e4c22bc856dd28aaa00f3fe08d26fb056d75f47591e70R36-R38))
* Introduced `RefreshWorkType` and `RefreshWorkResult` enums to represent work types and results, respectively, and refactored related code to use these enums. (`app/src/main/java/dev/hossain/trmnl/work/RefreshWorkType.kt`, [[1]](diffhunk://#diff-0fffd7295932d8fb46c5a1387b7178e8c38efecd2383948121da043a97be0158R1-R21); `app/src/main/java/dev/hossain/trmnl/work/RefreshWorkResult.kt`, [[2]](diffhunk://#diff-a1e6947b454776a9f6eb7d878ccf80eed0e9b66de8b727483f11c1119c46ccc1R1-R12)

### Updates to work scheduling:
* Modified `TrmnlImageRefreshWorker` to accept `PARAM_REFRESH_WORK_TYPE` and `PARAM_LOAD_NEXT_PLAYLIST_DISPLAY_IMAGE` as input data, enabling differentiation between one-time and periodic refresh work. (`app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt`, [[1]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL48-R59) [[2]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL100-R102)
* Updated `TrmnlWorkScheduler` to set input data for work requests, specifying the refresh work type and whether to load the next playlist image. (`app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt`, [[1]](diffhunk://#diff-756e71d44003929122168506f15a3d5f93fe3df7e65d0ffcc3fe869d9e87951eR116-R119) [[2]](diffhunk://#diff-756e71d44003929122168506f15a3d5f93fe3df7e65d0ffcc3fe869d9e87951eL124-R133) [[3]](diffhunk://#diff-756e71d44003929122168506f15a3d5f93fe3df7e65d0ffcc3fe869d9e87951eR154-R158)

### UI improvements:
* Enhanced the `DisplayRefreshLogScreen` to show the refresh job type (e.g., "Manual One-time Refresh" or "Automatic Scheduled Refresh") in the log details. (`app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt`, [[1]](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0R161) [[2]](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0R339-R352)
* Added a monospace font for the image name in the log details for better readability. (`app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt`, [app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.ktR324](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0R324))