### PR TITLE
[ADDED] Unit test for display image repository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,8 +126,9 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
     debugImplementation(libs.androidx.ui.tooling)
     testImplementation(libs.junit)
-    testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.test.mockk)
+    testImplementation(libs.test.truth)
 }
 
 ksp {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,8 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
     debugImplementation(libs.androidx.ui.tooling)
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 ksp {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,3 +137,9 @@ ksp {
     // kotlin-inject-anvil (requires 0.0.3+)
     arg("kotlin-inject-anvil-contributing-annotations", "com.slack.circuit.codegen.annotations.CircuitInject")
 }
+
+// Enable dynamic agent loading for tests needed by MockK
+// https://github.com/hossain-khan/android-trmnl-display/pull/106#issuecomment-2826350990
+tasks.withType<Test> {
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+}

--- a/app/src/main/java/dev/hossain/trmnl/data/RepositoryConfigProvider.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/RepositoryConfigProvider.kt
@@ -1,0 +1,21 @@
+package dev.hossain.trmnl.data
+
+import javax.inject.Inject
+
+/**
+ * Provides configuration for repository data sources. This class helps control whether repositories
+ * should use fake/mock data instead of real API data, which is useful for development and testing.
+ */
+class RepositoryConfigProvider
+    @Inject
+    constructor() {
+        /**
+         * Indicates if the app should use fake data instead of real API responses.
+         *
+         * @return Boolean value from [DevConfig.FAKE_API_RESPONSE]
+         */
+        val shouldUseFakeData: Boolean
+            get() {
+                return DevConfig.FAKE_API_RESPONSE
+            }
+    }

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -26,6 +26,7 @@ class TrmnlDisplayRepository
     constructor(
         private val apiService: TrmnlApiService,
         private val imageMetadataStore: ImageMetadataStore,
+        private val repositoryConfigProvider: RepositoryConfigProvider,
     ) {
         /**
          * Fetches display data for next plugin from the server using the provided access token.
@@ -35,7 +36,7 @@ class TrmnlDisplayRepository
          * @return A [TrmnlDisplayInfo] object containing the display data.
          */
         suspend fun getNextDisplayData(accessToken: String): TrmnlDisplayInfo {
-            if (FAKE_API_RESPONSE) {
+            if (repositoryConfigProvider.shouldUseFakeData) {
                 // Avoid using real API in debug mode
                 return fakeTrmnlDisplayInfo()
             }
@@ -71,7 +72,7 @@ class TrmnlDisplayRepository
          * @return A [TrmnlDisplayInfo] object containing the current display data.
          */
         suspend fun getCurrentDisplayData(accessToken: String): TrmnlDisplayInfo {
-            if (FAKE_API_RESPONSE) {
+            if (repositoryConfigProvider.shouldUseFakeData) {
                 // Avoid using real API in debug mode
                 return fakeTrmnlDisplayInfo()
             }

--- a/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
+++ b/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
@@ -1,0 +1,207 @@
+package dev.hossain.trmnl.data
+
+import com.slack.eithernet.ApiResult
+import dev.hossain.trmnl.network.TrmnlApiService
+import dev.hossain.trmnl.network.model.TrmnlCurrentImageResponse
+import dev.hossain.trmnl.network.model.TrmnlDisplayResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class TrmnlDisplayRepositoryTest {
+    private lateinit var repository: TrmnlDisplayRepository
+    private lateinit var apiService: TrmnlApiService
+    private lateinit var imageMetadataStore: ImageMetadataStore
+    private lateinit var repositoryConfigProvider: RepositoryConfigProvider
+
+    private val testAccessToken = "test-access-token"
+
+    @Before
+    fun setup() {
+        apiService = mockk()
+        repositoryConfigProvider = mockk()
+        imageMetadataStore = mockk(relaxed = true)
+
+        every { repositoryConfigProvider.shouldUseFakeData } returns false
+
+        repository =
+            TrmnlDisplayRepository(
+                apiService = apiService,
+                imageMetadataStore = imageMetadataStore,
+                repositoryConfigProvider = repositoryConfigProvider,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `getNextDisplayData should return mapped display info when API call succeeds`() =
+        runTest {
+            // Arrange
+            val successResponse =
+                TrmnlDisplayResponse(
+                    status = 200,
+                    imageUrl = "https://test.com/image.png",
+                    imageName = "test-image.png",
+                    refreshRate = 300L,
+                    error = null,
+                    updateFirmware = null,
+                    firmwareUrl = null,
+                    resetFirmware = null,
+                )
+            coEvery { apiService.getNextDisplayData(testAccessToken) } returns ApiResult.success(successResponse)
+
+            // Act
+            val result = repository.getNextDisplayData(testAccessToken)
+
+            // Assert
+            assertEquals(200, result.status)
+            assertEquals("https://test.com/image.png", result.imageUrl)
+            assertEquals("test-image.png", result.imageName)
+            assertEquals(300L, result.refreshIntervalSeconds)
+            assertNull(result.error)
+
+            // Verify metadata was saved
+            coVerify { imageMetadataStore.saveImageMetadata("https://test.com/image.png", 300L) }
+        }
+
+    @Test
+    fun `getNextDisplayData should handle error response`() =
+        runTest {
+            // Arrange
+            val errorResponse =
+                TrmnlDisplayResponse(
+                    status = 500,
+                    imageUrl = null,
+                    imageName = null,
+                    refreshRate = null,
+                    error = "Error fetching display",
+                    updateFirmware = null,
+                    firmwareUrl = null,
+                    resetFirmware = null,
+                )
+            coEvery { apiService.getNextDisplayData(testAccessToken) } returns ApiResult.success(errorResponse)
+
+            // Act
+            val result = repository.getNextDisplayData(testAccessToken)
+
+            // Assert
+            assertEquals(500, result.status)
+            assertEquals("", result.imageUrl)
+            assertEquals("", result.imageName)
+            assertNull(result.refreshIntervalSeconds)
+            assertEquals("Error fetching display", result.error)
+
+            // Verify metadata was NOT saved (empty URL)
+            coVerify(exactly = 0) { imageMetadataStore.saveImageMetadata(any(), any()) }
+        }
+
+    @Test
+    fun `getCurrentDisplayData should return mapped display info when API call succeeds`() =
+        runTest {
+            // Arrange
+            val successResponse =
+                TrmnlCurrentImageResponse(
+                    status = 200,
+                    imageUrl = "https://test.com/current.png",
+                    filename = "current-image.png",
+                    refreshRateSec = 600L,
+                    renderedAt = 1234567890L,
+                    error = null,
+                )
+            coEvery { apiService.getCurrentDisplayData(testAccessToken) } returns ApiResult.success(successResponse)
+
+            // Act
+            val result = repository.getCurrentDisplayData(testAccessToken)
+
+            // Assert
+            assertEquals(200, result.status)
+            assertEquals("https://test.com/current.png", result.imageUrl)
+            assertEquals("current-image.png", result.imageName)
+            assertEquals(600L, result.refreshIntervalSeconds)
+            assertNull(result.error)
+
+            // Verify metadata was saved
+            coVerify { imageMetadataStore.saveImageMetadata("https://test.com/current.png", 600L) }
+        }
+
+    @Test
+    fun `getCurrentDisplayData should handle error response`() =
+        runTest {
+            // Arrange
+            val errorResponse =
+                TrmnlCurrentImageResponse(
+                    status = 500,
+                    imageUrl = null,
+                    filename = null,
+                    refreshRateSec = null,
+                    renderedAt = null,
+                    error = "Device not found",
+                )
+            coEvery { apiService.getCurrentDisplayData(testAccessToken) } returns ApiResult.success(errorResponse)
+
+            // Act
+            val result = repository.getCurrentDisplayData(testAccessToken)
+
+            // Assert
+            assertEquals(500, result.status)
+            assertEquals("", result.imageUrl)
+            assertEquals("", result.imageName)
+            assertNull(result.refreshIntervalSeconds)
+            assertEquals("Device not found", result.error)
+
+            // Verify metadata was NOT saved (empty URL)
+            coVerify(exactly = 0) { imageMetadataStore.saveImageMetadata(any(), any()) }
+        }
+
+    @Test
+    fun `getNextDisplayData should return fake data when FAKE_API_RESPONSE is true`() =
+        runTest {
+            // Arrange
+            every { repositoryConfigProvider.shouldUseFakeData } returns true
+
+            // Act
+            val result = repository.getNextDisplayData(testAccessToken)
+
+            // Assert
+            assertEquals(200, result.status)
+            assert(result.imageUrl.contains("picsum.photos"))
+            assert(result.imageName.contains("picsum-mocked-image"))
+            assertEquals(600L, result.refreshIntervalSeconds)
+            assertNull(result.error)
+
+            // Verify API was NOT called
+            coVerify(exactly = 0) { apiService.getNextDisplayData(any()) }
+        }
+
+    @Test
+    fun `getCurrentDisplayData should return fake data when FAKE_API_RESPONSE is true`() =
+        runTest {
+            // Arrange
+            every { repositoryConfigProvider.shouldUseFakeData } returns true
+
+            // Act
+            val result = repository.getCurrentDisplayData(testAccessToken)
+
+            // Assert
+            assertEquals(200, result.status)
+            assert(result.imageUrl.contains("picsum.photos"))
+            assert(result.imageName.contains("picsum-mocked-image"))
+            assertEquals(600L, result.refreshIntervalSeconds)
+            assertNull(result.error)
+
+            // Verify API was NOT called
+            coVerify(exactly = 0) { apiService.getCurrentDisplayData(any()) }
+        }
+}

--- a/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
+++ b/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
@@ -16,6 +16,9 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
+/**
+ * Unit tests for [TrmnlDisplayRepository].
+ */
 class TrmnlDisplayRepositoryTest {
     private lateinit var repository: TrmnlDisplayRepository
     private lateinit var apiService: TrmnlApiService

--- a/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
+++ b/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
@@ -1,5 +1,6 @@
 package dev.hossain.trmnl.data
 
+import com.google.common.truth.Truth.assertThat
 import com.slack.eithernet.ApiResult
 import dev.hossain.trmnl.network.TrmnlApiService
 import dev.hossain.trmnl.network.model.TrmnlCurrentImageResponse
@@ -11,14 +12,9 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import kotlinx.coroutines.test.runTest
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
-/**
- * Unit tests for [TrmnlDisplayRepository].
- */
 class TrmnlDisplayRepositoryTest {
     private lateinit var repository: TrmnlDisplayRepository
     private lateinit var apiService: TrmnlApiService
@@ -69,11 +65,11 @@ class TrmnlDisplayRepositoryTest {
             val result = repository.getNextDisplayData(testAccessToken)
 
             // Assert
-            assertEquals(200, result.status)
-            assertEquals("https://test.com/image.png", result.imageUrl)
-            assertEquals("test-image.png", result.imageName)
-            assertEquals(300L, result.refreshIntervalSeconds)
-            assertNull(result.error)
+            assertThat(result.status).isEqualTo(200)
+            assertThat(result.imageUrl).isEqualTo("https://test.com/image.png")
+            assertThat(result.imageName).isEqualTo("test-image.png")
+            assertThat(result.refreshIntervalSeconds).isEqualTo(300L)
+            assertThat(result.error).isNull()
 
             // Verify metadata was saved
             coVerify { imageMetadataStore.saveImageMetadata("https://test.com/image.png", 300L) }
@@ -100,13 +96,13 @@ class TrmnlDisplayRepositoryTest {
             val result = repository.getNextDisplayData(testAccessToken)
 
             // Assert
-            assertEquals(500, result.status)
-            assertEquals("", result.imageUrl)
-            assertEquals("", result.imageName)
-            assertNull(result.refreshIntervalSeconds)
-            assertEquals("Error fetching display", result.error)
+            assertThat(result.status).isEqualTo(500)
+            assertThat(result.imageUrl).isEmpty()
+            assertThat(result.imageName).isEmpty()
+            assertThat(result.refreshIntervalSeconds).isNull()
+            assertThat(result.error).isEqualTo("Error fetching display")
 
-            // Verify metadata was NOT saved (empty URL)
+            // Verify metadata was NOT saved
             coVerify(exactly = 0) { imageMetadataStore.saveImageMetadata(any(), any()) }
         }
 
@@ -129,11 +125,11 @@ class TrmnlDisplayRepositoryTest {
             val result = repository.getCurrentDisplayData(testAccessToken)
 
             // Assert
-            assertEquals(200, result.status)
-            assertEquals("https://test.com/current.png", result.imageUrl)
-            assertEquals("current-image.png", result.imageName)
-            assertEquals(600L, result.refreshIntervalSeconds)
-            assertNull(result.error)
+            assertThat(result.status).isEqualTo(200)
+            assertThat(result.imageUrl).isEqualTo("https://test.com/current.png")
+            assertThat(result.imageName).isEqualTo("current-image.png")
+            assertThat(result.refreshIntervalSeconds).isEqualTo(600L)
+            assertThat(result.error).isNull()
 
             // Verify metadata was saved
             coVerify { imageMetadataStore.saveImageMetadata("https://test.com/current.png", 600L) }
@@ -158,18 +154,18 @@ class TrmnlDisplayRepositoryTest {
             val result = repository.getCurrentDisplayData(testAccessToken)
 
             // Assert
-            assertEquals(500, result.status)
-            assertEquals("", result.imageUrl)
-            assertEquals("", result.imageName)
-            assertNull(result.refreshIntervalSeconds)
-            assertEquals("Device not found", result.error)
+            assertThat(result.status).isEqualTo(500)
+            assertThat(result.imageUrl).isEmpty()
+            assertThat(result.imageName).isEmpty()
+            assertThat(result.refreshIntervalSeconds).isNull()
+            assertThat(result.error).isEqualTo("Device not found")
 
-            // Verify metadata was NOT saved (empty URL)
+            // Verify metadata was NOT saved
             coVerify(exactly = 0) { imageMetadataStore.saveImageMetadata(any(), any()) }
         }
 
     @Test
-    fun `getNextDisplayData should return fake data when FAKE_API_RESPONSE is true`() =
+    fun `getNextDisplayData should return fake data when shouldUseFakeData is true`() =
         runTest {
             // Arrange
             every { repositoryConfigProvider.shouldUseFakeData } returns true
@@ -178,18 +174,18 @@ class TrmnlDisplayRepositoryTest {
             val result = repository.getNextDisplayData(testAccessToken)
 
             // Assert
-            assertEquals(200, result.status)
-            assert(result.imageUrl.contains("picsum.photos"))
-            assert(result.imageName.contains("picsum-mocked-image"))
-            assertEquals(600L, result.refreshIntervalSeconds)
-            assertNull(result.error)
+            assertThat(result.status).isEqualTo(200)
+            assertThat(result.imageUrl).contains("picsum.photos")
+            assertThat(result.imageName).contains("mocked-image-grayscale&time")
+            assertThat(result.refreshIntervalSeconds).isEqualTo(600L)
+            assertThat(result.error).isNull()
 
             // Verify API was NOT called
             coVerify(exactly = 0) { apiService.getNextDisplayData(any()) }
         }
 
     @Test
-    fun `getCurrentDisplayData should return fake data when FAKE_API_RESPONSE is true`() =
+    fun `getCurrentDisplayData should return fake data when shouldUseFakeData is true`() =
         runTest {
             // Arrange
             every { repositoryConfigProvider.shouldUseFakeData } returns true
@@ -198,11 +194,11 @@ class TrmnlDisplayRepositoryTest {
             val result = repository.getCurrentDisplayData(testAccessToken)
 
             // Assert
-            assertEquals(200, result.status)
-            assert(result.imageUrl.contains("picsum.photos"))
-            assert(result.imageName.contains("picsum-mocked-image"))
-            assertEquals(600L, result.refreshIntervalSeconds)
-            assertNull(result.error)
+            assertThat(result.status).isEqualTo(200)
+            assertThat(result.imageUrl).contains("picsum.photos")
+            assertThat(result.imageName).contains("mocked-image-grayscale&time")
+            assertThat(result.refreshIntervalSeconds).isEqualTo(600L)
+            assertThat(result.error).isNull()
 
             // Verify API was NOT called
             coVerify(exactly = 0) { apiService.getCurrentDisplayData(any()) }

--- a/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
+++ b/app/src/test/java/dev/hossain/trmnl/data/TrmnlDisplayRepositoryTest.kt
@@ -15,6 +15,9 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
+/**
+ * Unit tests for [TrmnlDisplayRepository].
+ */
 class TrmnlDisplayRepositoryTest {
     private lateinit var repository: TrmnlDisplayRepository
     private lateinit var apiService: TrmnlApiService

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ coil = "3.1.0"
 mockk = "1.14.0"
 truth = "1.4.4"
 
-datastore = "1.1.5"
+datastore = "1.1.4"
 security-crypto = "1.1.0-alpha07"
 
 # https://developer.android.com/jetpack/androidx/releases/window

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ kotlinxSerializationProperties = "1.8.1"
 eithernet = "2.0.0"
 
 # https://developer.android.com/jetpack/androidx/releases/work
-workManager = "2.10.0"
+workManager = "2.10.1"
 
 # Coil
 # https://github.com/coil-kt/coil
@@ -46,7 +46,7 @@ coil = "3.1.0"
 mockk = "1.14.0"
 truth = "1.4.4"
 
-datastore = "1.1.4"
+datastore = "1.1.5"
 security-crypto = "1.1.0-alpha07"
 
 # https://developer.android.com/jetpack/androidx/releases/window

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ googleFonts = "1.7.8"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 kotlin = "2.1.10"
+kotlinxCoroutinesTest = "1.7.3"
 ksp = "2.1.10-1.0.31"
 lifecycleRuntimeKtx = "2.8.7"
 
@@ -41,6 +42,8 @@ workManager = "2.10.0"
 # Coil
 # https://github.com/coil-kt/coil
 coil = "3.1.0"
+
+mockk = "1.14.0"
 
 datastore = "1.1.4"
 security-crypto = "1.1.0-alpha07"
@@ -110,6 +113,8 @@ retrofit-converter-moshi = { group = "com.squareup.retrofit2", name = "converter
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx",name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-serialization-properties = { group = "org.jetbrains.kotlinx",name = "kotlinx-serialization-properties", version.ref = "kotlinxSerializationProperties" }
 
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 okhttp-mock-webserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
@@ -131,6 +136,10 @@ coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp"
 
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security-crypto" }
+
+# mocking library for Kotlin
+# https://github.com/mockk/mockk
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ workManager = "2.10.0"
 coil = "3.1.0"
 
 mockk = "1.14.0"
+truth = "1.4.4"
 
 datastore = "1.1.4"
 security-crypto = "1.1.0-alpha07"
@@ -139,7 +140,11 @@ androidx-security-crypto = { group = "androidx.security", name = "security-crypt
 
 # mocking library for Kotlin
 # https://github.com/mockk/mockk
-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+test-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+# Truth - Fluent assertions for Java and Android
+# https://truth.dev/
+test-truth = { module = "com.google.truth:truth", version.ref = "truth" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Refactored faker config to be injectable to allow testing

Fixes #100

This pull request introduces enhancements to testing, dependency management, and repository configuration. Key changes include the addition of new testing libraries, the creation of a `RepositoryConfigProvider` class to manage fake data usage, updates to the `TrmnlDisplayRepository` to use this provider, and the implementation of comprehensive unit tests for the repository.

### Testing Enhancements:
* Added new testing libraries: `kotlinx.coroutines.test`, `mockk`, and `truth` to `app/build.gradle.kts` and `gradle/libs.versions.toml` for improved testing capabilities. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R129-R131) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR16) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR46-R48) [[4]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR117-R118) [[5]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR141-R148)
* Configured dynamic agent loading for tests in `app/build.gradle.kts`, enabling MockK's advanced features.

### Repository Configuration:
* Introduced `RepositoryConfigProvider` class to manage whether fake data should be used during development or testing.
* Updated `TrmnlDisplayRepository` to use `RepositoryConfigProvider` for determining when to use fake data instead of hardcoding this logic. [[1]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517R29) [[2]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517L38-R39) [[3]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517L74-R75)

### Unit Tests:
* Added comprehensive unit tests for `TrmnlDisplayRepository` to validate API responses, error handling, and the use of fake data when enabled. Tests utilize MockK and Truth for mocking and assertions.
