### PR TITLE
[ADDED] New button to load next plugin image

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -38,7 +38,7 @@ class TrmnlDisplayRepository
         suspend fun getNextDisplayData(accessToken: String): TrmnlDisplayInfo {
             if (repositoryConfigProvider.shouldUseFakeData) {
                 // Avoid using real API in debug mode
-                return fakeTrmnlDisplayInfo()
+                return fakeTrmnlDisplayInfo(apiUsed = "next-image")
             }
 
             val response = apiService.getNextDisplayData(accessToken).successOrNull()
@@ -74,7 +74,7 @@ class TrmnlDisplayRepository
         suspend fun getCurrentDisplayData(accessToken: String): TrmnlDisplayInfo {
             if (repositoryConfigProvider.shouldUseFakeData) {
                 // Avoid using real API in debug mode
-                return fakeTrmnlDisplayInfo()
+                return fakeTrmnlDisplayInfo(apiUsed = "current-image")
             }
 
             val response = apiService.getCurrentDisplayData(accessToken).successOrNull()
@@ -116,10 +116,10 @@ class TrmnlDisplayRepository
          *
          * ℹ️ This is only used when [FAKE_API_RESPONSE] is set to `true`.
          */
-        private suspend fun fakeTrmnlDisplayInfo(): TrmnlDisplayInfo {
+        private suspend fun fakeTrmnlDisplayInfo(apiUsed: String): TrmnlDisplayInfo {
             Timber.d("DEBUG: Using mock data for display info")
             val timestampMin = System.currentTimeMillis() / 60_000 // Changes every minute
-            val mockImageUrl = "https://picsum.photos/300/200?grayscale&time=$timestampMin"
+            val mockImageUrl = "https://picsum.photos/300/200?grayscale&time=$timestampMin&api=$apiUsed"
             val mockRefreshRate = 600L
 
             // Save mock data to the data store

--- a/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt
@@ -41,6 +41,8 @@ class TrmnlDisplayRepository
                 return fakeTrmnlDisplayInfo(apiUsed = "next-image")
             }
 
+            Timber.i("Fetching next playlist item display data from server")
+
             val response = apiService.getNextDisplayData(accessToken).successOrNull()
 
             // Map the response to the display info
@@ -76,6 +78,8 @@ class TrmnlDisplayRepository
                 // Avoid using real API in debug mode
                 return fakeTrmnlDisplayInfo(apiUsed = "current-image")
             }
+
+            Timber.i("Fetching current display data from server")
 
             val response = apiService.getCurrentDisplayData(accessToken).successOrNull()
 

--- a/app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
@@ -88,6 +90,8 @@ data object TrmnlMirrorDisplayScreen : Screen {
 
     sealed class Event : CircuitUiEvent {
         data object RefreshRequested : Event()
+
+        data object LoadNextPluginImage : Event()
 
         data object ConfigureRequested : Event()
 
@@ -213,6 +217,10 @@ class TrmnlMirrorDisplayPresenter
 
                         TrmnlMirrorDisplayScreen.Event.ToggleOverlayControls -> {
                             overlayControlsVisible = !overlayControlsVisible
+                        }
+
+                        TrmnlMirrorDisplayScreen.Event.LoadNextPluginImage -> {
+                            trmnlWorkScheduler.startOneTimeImageRefreshWork(loadNextPlaylistImage = true)
                         }
                     }
                 },
@@ -385,6 +393,26 @@ private fun OverlaySettingsView(
                 text = {
                     Text(
                         "Refresh TRMNL Image",
+                        style = fabTextStyle,
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+            )
+
+            ExtendedFloatingActionButton(
+                onClick = {
+                    state.eventSink(TrmnlMirrorDisplayScreen.Event.LoadNextPluginImage)
+                },
+                icon = {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        contentDescription = null,
+                        modifier = if (isExpandedWidth) Modifier.size(32.dp) else Modifier,
+                    )
+                },
+                text = {
+                    Text(
+                        "Load Next Playlist Item",
                         style = fabTextStyle,
                         fontWeight = FontWeight.Bold,
                     )

--- a/app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt
@@ -15,8 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.ArrowForward
-import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
@@ -372,7 +371,7 @@ private fun OverlaySettingsView(
                 },
                 text = {
                     Text(
-                        "Configure API Token",
+                        "Configure TRMNL API Token",
                         style = fabTextStyle,
                         fontWeight = FontWeight.Bold,
                     )
@@ -392,7 +391,7 @@ private fun OverlaySettingsView(
                 },
                 text = {
                     Text(
-                        "Refresh TRMNL Image",
+                        "Refresh Current Playlist Image",
                         style = fabTextStyle,
                         fontWeight = FontWeight.Bold,
                     )
@@ -412,7 +411,7 @@ private fun OverlaySettingsView(
                 },
                 text = {
                     Text(
-                        "Load Next Playlist Item",
+                        "Load Next Playlist Image",
                         style = fabTextStyle,
                         fontWeight = FontWeight.Bold,
                     )
@@ -425,14 +424,14 @@ private fun OverlaySettingsView(
                 },
                 icon = {
                     Icon(
-                        imageVector = Icons.Default.DateRange,
+                        imageVector = Icons.AutoMirrored.Filled.List,
                         contentDescription = null,
                         modifier = if (isExpandedWidth) Modifier.size(32.dp) else Modifier,
                     )
                 },
                 text = {
                     Text(
-                        "View Refresh Logs",
+                        "View Image Refresh Logs",
                         style = fabTextStyle,
                         fontWeight = FontWeight.Bold,
                     )

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt
@@ -104,7 +104,12 @@ class TrmnlImageRefreshWorker(
         }
 
         // ✅ Log success and update image
-        refreshLogManager.addSuccessLog(trmnlDisplayInfo.imageUrl, trmnlDisplayInfo.imageName, trmnlDisplayInfo.refreshIntervalSeconds, workTypeValue)
+        refreshLogManager.addSuccessLog(
+            imageUrl = trmnlDisplayInfo.imageUrl,
+            imageName = trmnlDisplayInfo.imageName,
+            refreshIntervalSeconds = trmnlDisplayInfo.refreshIntervalSeconds,
+            imageRefreshWorkType = workTypeValue,
+        )
 
         // Check if we should adapt refresh rate
         val refreshRate = trmnlDisplayInfo.refreshIntervalSeconds

--- a/app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt
+++ b/app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt
@@ -131,7 +131,7 @@ class TrmnlWorkScheduler
          * Start a one-time image refresh work immediately with option to load next playlist item image.
          */
         fun startOneTimeImageRefreshWork(loadNextPlaylistImage: Boolean = false) {
-            Timber.d("Starting one-time image refresh work")
+            Timber.d("Starting one-time image refresh work with loadNextPlaylistImage: $loadNextPlaylistImage")
 
             if (trmnlTokenDataStore.hasTokenSync().not()) {
                 Timber.w("Token not set, skipping one-time image refresh work")


### PR DESCRIPTION
Fixes #97

This pull request introduces functionality to handle both the current and next playlist images in the TRMNL application, along with UI updates to support these changes. It also improves logging and mock data handling. Below are the most significant changes grouped by theme.

### Backend Enhancements:
* Updated `TrmnlDisplayRepository` to differentiate between fetching current and next playlist images by adding an `apiUsed` parameter to the `fakeTrmnlDisplayInfo` method and logging the type of data being fetched. (`app/src/main/java/dev/hossain/trmnl/data/TrmnlDisplayRepository.kt`, [[1]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517L41-R45) [[2]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517L77-R83) [[3]](diffhunk://#diff-24b74d9788115a0f60c040b3532535a27cf82766f7129b7d1b68575489c82517L119-R126)

* Modified `TrmnlImageRefreshWorker` to support fetching either the current or next playlist image based on the `loadNextPluginImage` flag, ensuring accurate logging and error handling for both scenarios. (`app/src/main/java/dev/hossain/trmnl/work/TrmnlImageRefreshWorker.kt`, [[1]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL74-R115) [[2]](diffhunk://#diff-50344fb6965d07f61a70ac1d3f59be30ea59ca8e6a02557e0d60b578a44eb60cL117-R133)

* Enhanced `TrmnlWorkScheduler` to log whether the next playlist image is being loaded during one-time refresh work. (`app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.kt`, [app/src/main/java/dev/hossain/trmnl/work/TrmnlWorkScheduler.ktL134-R134](diffhunk://#diff-756e71d44003929122168506f15a3d5f93fe3df7e65d0ffcc3fe869d9e87951eL134-R134))

### UI Updates:
* Added a new event, `LoadNextPluginImage`, to `TrmnlMirrorDisplayScreen` and updated the presenter to handle this event by triggering a one-time refresh for the next playlist image. (`app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt`, [[1]](diffhunk://#diff-24d6d54ed9c96801768d0eb4a71fdb30941a75ef5d53548cb5d0c9827dbb1878R93-R94) [[2]](diffhunk://#diff-24d6d54ed9c96801768d0eb4a71fdb30941a75ef5d53548cb5d0c9827dbb1878R220-R223)

* Updated the `OverlaySettingsView` to include a new button for loading the next playlist image, along with changes to button labels for clarity (e.g., "Refresh Current Playlist Image" and "View Image Refresh Logs"). (`app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt`, [[1]](diffhunk://#diff-24d6d54ed9c96801768d0eb4a71fdb30941a75ef5d53548cb5d0c9827dbb1878L367-R374) [[2]](diffhunk://#diff-24d6d54ed9c96801768d0eb4a71fdb30941a75ef5d53548cb5d0c9827dbb1878L387-R414) [[3]](diffhunk://#diff-24d6d54ed9c96801768d0eb4a71fdb30941a75ef5d53548cb5d0c9827dbb1878L400-R434)

### Icon and Styling Adjustments:
* Replaced outdated icons (e.g., `DateRange`) with more contextually appropriate ones (e.g., `ArrowForward` and `List`) to align with the new functionality. (`app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.kt`, [app/src/main/java/dev/hossain/trmnl/ui/display/TrmnlMirrorDisplayScreen.ktL17-R18](diffhunk://#diff-24d6d54ed9c96801768d0eb4a71fdb30941a75ef5d53548cb5d0c9827dbb1878L17-R18))