### PR TITLE
[FIXED] Hack used earlier to get work info

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -53,9 +54,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.asFlow
 import androidx.work.WorkInfo
-import androidx.work.WorkManager
 import coil3.compose.AsyncImage
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
@@ -74,7 +73,9 @@ import dev.hossain.trmnl.data.TrmnlTokenDataStore
 import dev.hossain.trmnl.di.AppScope
 import dev.hossain.trmnl.ui.display.TrmnlMirrorDisplayScreen
 import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult
+import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult.*
 import dev.hossain.trmnl.util.CoilRequestUtils
+import dev.hossain.trmnl.util.NextImageRefreshDisplayInfo
 import dev.hossain.trmnl.util.isHttpError
 import dev.hossain.trmnl.util.nextRunTime
 import dev.hossain.trmnl.util.toColor
@@ -82,7 +83,6 @@ import dev.hossain.trmnl.util.toDisplayString
 import dev.hossain.trmnl.util.toIcon
 import dev.hossain.trmnl.work.TrmnlImageUpdateManager
 import dev.hossain.trmnl.work.TrmnlWorkScheduler
-import dev.hossain.trmnl.work.TrmnlWorkScheduler.Companion.IMAGE_REFRESH_PERIODIC_WORK_NAME
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
@@ -105,6 +105,7 @@ data class AppSettingsScreen(
         val accessToken: String,
         val isLoading: Boolean = false,
         val validationResult: ValidationResult? = null,
+        val nextRefreshJobInfo: NextImageRefreshDisplayInfo? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -144,6 +145,11 @@ data class AppSettingsScreen(
          * Event triggered when the back button is pressed.
          */
         data object BackPressed : Event()
+
+        /**
+         * Event triggered to cancel the scheduled work.
+         */
+        data object CancelScheduledWork : Event()
     }
 }
 
@@ -168,6 +174,12 @@ class AppSettingsPresenter
             var validationResult by remember { mutableStateOf<ValidationResult?>(null) }
             val scope = rememberCoroutineScope()
 
+            val nextRefreshInfo by produceState<NextImageRefreshDisplayInfo?>(null) {
+                trmnlWorkScheduler.getScheduledWorkInfo().collect { workInfo ->
+                    value = workInfo?.nextRunTime()
+                }
+            }
+
             // Load saved token if available
             LaunchedEffect(Unit) {
                 trmnlTokenDataStore.accessTokenFlow.collect { savedToken ->
@@ -181,6 +193,7 @@ class AppSettingsPresenter
                 accessToken = accessToken,
                 isLoading = isLoading,
                 validationResult = validationResult,
+                nextRefreshJobInfo = nextRefreshInfo,
                 eventSink = { event ->
                     when (event) {
                         is AppSettingsScreen.Event.AccessTokenChanged -> {
@@ -199,19 +212,19 @@ class AppSettingsPresenter
                                 if (response.status.isHttpError()) {
                                     // Handle explicit error response
                                     val errorMessage = response.error ?: "Device not found"
-                                    validationResult = ValidationResult.Failure(errorMessage)
+                                    validationResult = Failure(errorMessage)
                                 } else if (response.imageUrl.isNotBlank()) {
                                     // Success case - we have an image URL
                                     trmnlImageUpdateManager.updateImage(response.imageUrl, response.refreshIntervalSeconds)
                                     validationResult =
-                                        ValidationResult.Success(
+                                        Success(
                                             response.imageUrl,
                                             response.refreshIntervalSeconds ?: DEFAULT_REFRESH_INTERVAL_SEC,
                                         )
                                 } else {
                                     // No error but also no image URL
                                     val errorMessage = response.error ?: ""
-                                    validationResult = ValidationResult.Failure("$errorMessage No image URL received.")
+                                    validationResult = Failure("$errorMessage No image URL received.")
                                 }
                                 isLoading = false
                             }
@@ -236,6 +249,10 @@ class AppSettingsPresenter
 
                         AppSettingsScreen.Event.BackPressed -> {
                             navigator.pop()
+                        }
+
+                        AppSettingsScreen.Event.CancelScheduledWork -> {
+                            trmnlWorkScheduler.cancelImageRefreshWork()
                         }
                     }
                 },
@@ -267,6 +284,7 @@ fun AppSettingsContent(
     val context = LocalContext.current
     val scrollState = rememberScrollState()
     val hasToken = state.accessToken.isNotBlank()
+    val trmnlWorkScheduler = remember { TrmnlWorkScheduler(context, TrmnlTokenDataStore(context)) }
 
     // Control password visibility
     var passwordVisible by remember { mutableStateOf(false) }
@@ -444,34 +462,16 @@ fun AppSettingsContent(
             }
 
             Spacer(modifier = Modifier.height(24.dp))
-            WorkScheduleStatusCard(modifier = Modifier.fillMaxWidth())
+            WorkScheduleStatusCard(state = state, modifier = Modifier.fillMaxWidth())
         }
     }
 }
 
 @Composable
 private fun WorkScheduleStatusCard(
+    state: AppSettingsScreen.State,
     modifier: Modifier = Modifier,
-    workManager: WorkManager = WorkManager.getInstance(LocalContext.current),
-    workName: String = IMAGE_REFRESH_PERIODIC_WORK_NAME,
 ) {
-    val context = LocalContext.current
-    var workInfo by remember { mutableStateOf<WorkInfo?>(null) }
-    var isLoading by remember { mutableStateOf(true) }
-    val scope = rememberCoroutineScope()
-
-    // Fetch work info
-    LaunchedEffect(workName) {
-        isLoading = true
-        workManager
-            .getWorkInfosForUniqueWorkLiveData(workName)
-            .asFlow()
-            .collect { workInfoList ->
-                workInfo = workInfoList.firstOrNull()
-                isLoading = false
-            }
-    }
-
     Card(
         modifier = modifier.fillMaxWidth(),
         colors =
@@ -491,94 +491,81 @@ private fun WorkScheduleStatusCard(
                 modifier = Modifier.padding(bottom = 8.dp),
             )
 
-            if (isLoading) {
-                CircularProgressIndicator(
-                    modifier =
-                        Modifier
-                            .size(24.dp)
-                            .align(Alignment.CenterHorizontally)
-                            .padding(top = 8.dp),
-                )
-            } else if (workInfo == null) {
-                Text(
-                    text = "No scheduled refresh work found.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            } else {
+            val nextRefreshJobInfo: NextImageRefreshDisplayInfo? = state.nextRefreshJobInfo
+            if (nextRefreshJobInfo != null) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.padding(vertical = 4.dp),
                 ) {
                     Icon(
-                        imageVector = workInfo?.state.toIcon(),
+                        imageVector = nextRefreshJobInfo.workerState.toIcon(),
                         contentDescription = null,
-                        tint = workInfo?.state.toColor(),
+                        tint = nextRefreshJobInfo.workerState.toColor(),
                         modifier = Modifier.size(20.dp),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = "Status: ${workInfo?.state.toDisplayString()}",
+                        text = "Status: ${nextRefreshJobInfo.workerState.toDisplayString()}",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = workInfo?.state.toColor(),
+                        color = nextRefreshJobInfo.workerState.toColor(),
                     )
                 }
 
-                // Show next schedule time if available
-                val nextRefreshTimeInfo = workInfo?.nextRunTime()
-                if (nextRefreshTimeInfo != null) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(vertical = 4.dp),
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.DateRange,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Next refresh: ${nextRefreshJobInfo.timeUntilNextRefresh}",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+
+                Text(
+                    text = "Scheduled for: ${nextRefreshJobInfo.nextRefreshOnDateTime}",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(start = 28.dp, top = 2.dp),
+                )
+
+                // Add a button to cancel the work if it's scheduled
+                if (nextRefreshJobInfo.workerState == WorkInfo.State.ENQUEUED ||
+                    nextRefreshJobInfo.workerState == WorkInfo.State.RUNNING ||
+                    nextRefreshJobInfo.workerState == WorkInfo.State.BLOCKED
+                ) {
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Button(
+                        onClick = {
+                            state.eventSink(AppSettingsScreen.Event.CancelScheduledWork)
+                        },
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.error,
+                            ),
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
                         Icon(
-                            imageVector = Icons.Default.DateRange,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = "Cancel scheduled work",
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = "Next refresh: ${nextRefreshTimeInfo.timeUntilNextRefresh}",
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
-
-                    Text(
-                        text = "Scheduled for: ${nextRefreshTimeInfo.nextRefreshOnDateTime}",
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(start = 28.dp, top = 2.dp),
-                    )
-
-                    // Add a button to cancel the work if it's scheduled
-                    if (workInfo?.state == WorkInfo.State.ENQUEUED ||
-                        workInfo?.state == WorkInfo.State.RUNNING ||
-                        workInfo?.state == WorkInfo.State.BLOCKED
-                    ) {
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        Button(
-                            onClick = {
-                                scope.launch {
-                                    workManager.cancelUniqueWork(workName)
-                                }
-                            },
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.error,
-                                ),
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Clear,
-                                contentDescription = "Cancel scheduled work",
-                                modifier = Modifier.size(20.dp),
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text("Cancel Periodic Refresh Job")
-                        }
+                        Text("Cancel Periodic Refresh Job")
                     }
                 }
+            } else {
+                Text(
+                    text = "No scheduled refresh work found.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
             }
         }
     }

--- a/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -173,6 +174,7 @@ class AppSettingsPresenter
             var isLoading by remember { mutableStateOf(false) }
             var validationResult by remember { mutableStateOf<ValidationResult?>(null) }
             val scope = rememberCoroutineScope()
+            val focusManager = LocalFocusManager.current
 
             val nextRefreshInfo by produceState<NextImageRefreshDisplayInfo?>(null) {
                 trmnlWorkScheduler.getScheduledWorkInfo().collect { workInfo ->
@@ -204,6 +206,7 @@ class AppSettingsPresenter
 
                         AppSettingsScreen.Event.ValidateToken -> {
                             scope.launch {
+                                focusManager.clearFocus()
                                 isLoading = true
                                 validationResult = null
 

--- a/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -328,7 +329,8 @@ fun AppSettingsContent(
                     .fillMaxSize()
                     .verticalScroll(scrollState)
                     .padding(innerPadding)
-                    .padding(horizontal = 32.dp),
+                    .padding(horizontal = 32.dp)
+                    .imePadding(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {

--- a/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -51,6 +52,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -372,7 +374,17 @@ fun AppSettingsContent(
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
                 visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                keyboardOptions =
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Done,
+                    ),
+                keyboardActions =
+                    KeyboardActions(
+                        onDone = {
+                            state.eventSink(AppSettingsScreen.Event.ValidateToken)
+                        },
+                    ),
                 trailingIcon = {
                     IconButton(onClick = { passwordVisible = !passwordVisible }) {
                         Icon(

--- a/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
@@ -77,7 +77,8 @@ import dev.hossain.trmnl.data.TrmnlTokenDataStore
 import dev.hossain.trmnl.di.AppScope
 import dev.hossain.trmnl.ui.display.TrmnlMirrorDisplayScreen
 import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult
-import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult.*
+import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult.Failure
+import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult.Success
 import dev.hossain.trmnl.util.CoilRequestUtils
 import dev.hossain.trmnl.util.NextImageRefreshDisplayInfo
 import dev.hossain.trmnl.util.isHttpError

--- a/app/src/main/java/dev/hossain/trmnl/util/WorkInfoExtensions.kt
+++ b/app/src/main/java/dev/hossain/trmnl/util/WorkInfoExtensions.kt
@@ -65,14 +65,14 @@ fun WorkInfo?.nextRunTime(): NextImageRefreshDisplayInfo? {
         return null
     }
 
-    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    val formatter = DateTimeFormatter.ofPattern("MMM dd 'at' hh:mm:ss a")
     val nextRunTime: String =
         Instant
             .ofEpochMilli(nextScheduleTimeMillis)
             .atZone(ZoneId.systemDefault())
             .format(formatter)
 
-    val timeUntil = nextScheduleTimeMillis - System.currentTimeMillis()
+    val timeUntil = nextScheduleTimeMillis - Instant.now().toEpochMilli()
     val timeUntilText =
         when {
             timeUntil <= 0 -> "any moment now"

--- a/app/src/main/java/dev/hossain/trmnl/util/WorkInfoExtensions.kt
+++ b/app/src/main/java/dev/hossain/trmnl/util/WorkInfoExtensions.kt
@@ -20,6 +20,7 @@ import java.time.format.DateTimeFormatter
  * @see [WorkInfo.nextRunTime]
  */
 data class NextImageRefreshDisplayInfo(
+    val workerState: WorkInfo.State,
     val timeUntilNextRefresh: String,
     val nextRefreshOnDateTime: String,
     val nextRefreshTimeMillis: Long,
@@ -60,7 +61,11 @@ fun WorkInfo.State?.toIcon(): ImageVector =
     }
 
 fun WorkInfo?.nextRunTime(): NextImageRefreshDisplayInfo? {
-    val nextScheduleTimeMillis = this?.nextScheduleTimeMillis ?: 0L
+    if (this == null) {
+        return null
+    }
+
+    val nextScheduleTimeMillis = nextScheduleTimeMillis
     if (nextScheduleTimeMillis > 0 && nextScheduleTimeMillis != Long.MAX_VALUE) {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         val nextRunTime: String =
@@ -78,6 +83,7 @@ fun WorkInfo?.nextRunTime(): NextImageRefreshDisplayInfo? {
                 else -> "in ${timeUntil / 3600000} hours"
             }
         return NextImageRefreshDisplayInfo(
+            workerState = state,
             timeUntilNextRefresh = timeUntilText,
             nextRefreshOnDateTime = nextRunTime,
             nextRefreshTimeMillis = nextScheduleTimeMillis,

--- a/app/src/main/java/dev/hossain/trmnl/util/WorkInfoExtensions.kt
+++ b/app/src/main/java/dev/hossain/trmnl/util/WorkInfoExtensions.kt
@@ -65,30 +65,25 @@ fun WorkInfo?.nextRunTime(): NextImageRefreshDisplayInfo? {
         return null
     }
 
-    val nextScheduleTimeMillis = nextScheduleTimeMillis
-    if (nextScheduleTimeMillis > 0 && nextScheduleTimeMillis != Long.MAX_VALUE) {
-        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-        val nextRunTime: String =
-            Instant
-                .ofEpochMilli(nextScheduleTimeMillis)
-                .atZone(ZoneId.systemDefault())
-                .format(formatter)
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    val nextRunTime: String =
+        Instant
+            .ofEpochMilli(nextScheduleTimeMillis)
+            .atZone(ZoneId.systemDefault())
+            .format(formatter)
 
-        val timeUntil = nextScheduleTimeMillis - System.currentTimeMillis()
-        val timeUntilText =
-            when {
-                timeUntil <= 0 -> "any moment now"
-                timeUntil < 60000 -> "in ${timeUntil / 1000} seconds"
-                timeUntil < 3600000 -> "in ${timeUntil / 60000} minutes"
-                else -> "in ${timeUntil / 3600000} hours"
-            }
-        return NextImageRefreshDisplayInfo(
-            workerState = state,
-            timeUntilNextRefresh = timeUntilText,
-            nextRefreshOnDateTime = nextRunTime,
-            nextRefreshTimeMillis = nextScheduleTimeMillis,
-        )
-    } else {
-        return null
-    }
+    val timeUntil = nextScheduleTimeMillis - System.currentTimeMillis()
+    val timeUntilText =
+        when {
+            timeUntil <= 0 -> "any moment now"
+            timeUntil < 60000 -> "in ${timeUntil / 1000} seconds"
+            timeUntil < 3600000 -> "in ${timeUntil / 60000} minutes"
+            else -> "in ${timeUntil / 3600000} hours"
+        }
+    return NextImageRefreshDisplayInfo(
+        workerState = state,
+        timeUntilNextRefresh = timeUntilText,
+        nextRefreshOnDateTime = nextRunTime,
+        nextRefreshTimeMillis = nextScheduleTimeMillis,
+    )
 }


### PR DESCRIPTION
Fixes #52

This pull request introduces enhancements to the `AppSettingsScreen` in the `trmnl` app, focusing on improving the handling and display of scheduled work information, as well as cleaning up unused imports and simplifying logic. The main updates include integrating `NextImageRefreshDisplayInfo` for better work scheduling visibility, adding a new event to cancel scheduled work, and refactoring the `WorkScheduleStatusCard` to rely on state-driven data.

### Enhancements to scheduled work handling:

* Added a new `CancelScheduledWork` event to allow users to cancel scheduled image refresh jobs. (`[[1]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9R150-R154)`, `[[2]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9R257-R260)`, `[[3]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L542-R551)`)
* Introduced `NextImageRefreshDisplayInfo` to encapsulate worker state and scheduling details, improving the clarity of scheduled work information. (`[[1]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9R110)`, `[[2]](diffhunk://#diff-acd4d8018df94bc2d703a0764221e618ab67e745aaf06d5dec10c454d5cd615eR23)`, `[[3]](diffhunk://#diff-acd4d8018df94bc2d703a0764221e618ab67e745aaf06d5dec10c454d5cd615eR86)`)
* Updated the `WorkScheduleStatusCard` to use `NextImageRefreshDisplayInfo` from the state, removing direct dependencies on `WorkManager` and simplifying its logic. (`[[1]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L447-L474)`, `[[2]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L494-L529)`, `[[3]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L581-R573)`)

### UI/UX improvements:

* Added `imePadding` to the main content layout for better handling of on-screen keyboards. (`[app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.ktL310-R333](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L310-R333)`)
* Ensured the keyboard focus is cleared when validating the token to improve user experience. (`[app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.ktR210](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9R210)`)

### Code cleanup and refactoring:

* Removed unused imports and deprecated code related to `WorkManager` and `IMAGE_REFRESH_PERIODIC_WORK_NAME`. (`[[1]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L56-L58)`, `[[2]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9R78-L85)`, `[[3]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L447-L474)`)
* Refactored validation result assignments to use direct enum imports for brevity. (`[app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.ktL202-R231](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L202-R231)`)