### PR TITLE
[ADDED] UI preview for app settings and log view

### DIFF
--- a/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/refreshlog/DisplayRefreshLogScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
@@ -50,9 +51,11 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dev.hossain.trmnl.BuildConfig
 import dev.hossain.trmnl.R
+import dev.hossain.trmnl.data.AppConfig.DEFAULT_REFRESH_INTERVAL_SEC
 import dev.hossain.trmnl.data.log.TrmnlRefreshLog
 import dev.hossain.trmnl.data.log.TrmnlRefreshLogManager
 import dev.hossain.trmnl.di.AppScope
+import dev.hossain.trmnl.ui.theme.TrmnlDisplayAppTheme
 import dev.hossain.trmnl.util.getTimeElapsedString
 import dev.hossain.trmnl.work.RefreshWorkType
 import dev.hossain.trmnl.work.TrmnlWorkScheduler
@@ -61,6 +64,7 @@ import kotlinx.parcelize.Parcelize
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 /**
  * A screen that displays the refresh logs of the TRMNL display.
@@ -251,7 +255,7 @@ fun DisplayRefreshLogContent(
                     contentPadding = PaddingValues(16.dp),
                 ) {
                     items(state.logs) { log ->
-                        LogItem(log = log)
+                        LogItemView(log = log)
                     }
                 }
             }
@@ -264,7 +268,7 @@ fun DisplayRefreshLogContent(
  * Displays different information based on whether the log represents a success or failure.
  */
 @Composable
-private fun LogItem(
+private fun LogItemView(
     log: TrmnlRefreshLog,
     modifier: Modifier = Modifier,
 ) {
@@ -462,5 +466,99 @@ private fun DebugControls(
         ) {
             Text("Start Refresh Worker")
         }
+    }
+}
+
+@Preview(name = "Display Refresh Log Content - Empty")
+@Composable
+private fun PreviewDisplayRefreshLogContentEmpty() {
+    TrmnlDisplayAppTheme {
+        DisplayRefreshLogContent(
+            state =
+                DisplayRefreshLogScreen.State(
+                    logs = emptyList(),
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "Display Refresh Log Content - With Logs")
+@Composable
+private fun PreviewDisplayRefreshLogContentWithLogs() {
+    val sampleLogs =
+        listOf(
+            TrmnlRefreshLog(
+                timestamp = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5),
+                success = true,
+                imageUrl = "https://example.com/image1.png",
+                imageName = "preview-image.bmp",
+                refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SEC,
+                imageRefreshWorkType = RefreshWorkType.PERIODIC.name,
+                error = null,
+            ),
+            TrmnlRefreshLog(
+                timestamp = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1),
+                success = false,
+                imageUrl = null,
+                imageName = "preview-image.bmp",
+                refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SEC,
+                imageRefreshWorkType = RefreshWorkType.ONE_TIME.name,
+                error = "Failed to connect to server (HTTP 500)",
+            ),
+            TrmnlRefreshLog(
+                timestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1),
+                success = true,
+                imageUrl = "https://example.com/image2.png",
+                imageName = "preview-image.bmp",
+                refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SEC,
+                imageRefreshWorkType = RefreshWorkType.PERIODIC.name,
+                error = null,
+            ),
+        )
+    TrmnlDisplayAppTheme {
+        DisplayRefreshLogContent(
+            state =
+                DisplayRefreshLogScreen.State(
+                    logs = sampleLogs,
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "Log Item View - Success")
+@Composable
+private fun PreviewLogItemViewSuccess() {
+    val log =
+        TrmnlRefreshLog(
+            timestamp = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(10),
+            success = true,
+            imageUrl = "https://images.unsplash.com/photo-1617591897383-14876a3e6d1a",
+            imageName = "preview-image.bmp",
+            refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SEC,
+            imageRefreshWorkType = RefreshWorkType.PERIODIC.name,
+            error = null,
+        )
+    TrmnlDisplayAppTheme {
+        LogItemView(log = log)
+    }
+}
+
+@Preview(name = "Log Item View - Failure")
+@Composable
+private fun PreviewLogItemViewFailure() {
+    val log =
+        TrmnlRefreshLog(
+            timestamp = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(30),
+            success = false,
+            imageUrl = null,
+            imageName = "preview-image.bmp",
+            refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SEC,
+            imageRefreshWorkType = RefreshWorkType.ONE_TIME.name,
+            error = "Network timeout while fetching image.",
+        )
+    TrmnlDisplayAppTheme {
+        LogItemView(log = log)
     }
 }

--- a/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/trmnl/ui/settings/AppSettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.work.WorkInfo
 import coil3.compose.AsyncImage
@@ -79,6 +80,7 @@ import dev.hossain.trmnl.ui.display.TrmnlMirrorDisplayScreen
 import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult
 import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult.Failure
 import dev.hossain.trmnl.ui.settings.AppSettingsScreen.ValidationResult.Success
+import dev.hossain.trmnl.ui.theme.TrmnlDisplayAppTheme
 import dev.hossain.trmnl.util.CoilRequestUtils
 import dev.hossain.trmnl.util.NextImageRefreshDisplayInfo
 import dev.hossain.trmnl.util.isHttpError
@@ -90,6 +92,9 @@ import dev.hossain.trmnl.work.TrmnlImageUpdateManager
 import dev.hossain.trmnl.work.TrmnlWorkScheduler
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 /**
  * Screen for configuring the TRMNL mirror app settings.
@@ -595,7 +600,7 @@ private fun FakeApiInfoBanner(modifier: Modifier = Modifier) {
         modifier = modifier,
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
             ),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.tertiary),
     ) {
@@ -610,7 +615,7 @@ private fun FakeApiInfoBanner(modifier: Modifier = Modifier) {
             Icon(
                 imageVector = Icons.Default.Info,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.tertiary,
+                tint = MaterialTheme.colorScheme.secondary,
             )
 
             Column {
@@ -632,5 +637,155 @@ private fun FakeApiInfoBanner(modifier: Modifier = Modifier) {
                 )
             }
         }
+    }
+}
+
+@Preview(name = "App Settings Content - Initial State")
+@Composable
+private fun PreviewAppSettingsContentInitial() {
+    TrmnlDisplayAppTheme {
+        AppSettingsContent(
+            state =
+                AppSettingsScreen.State(
+                    accessToken = "",
+                    isLoading = false,
+                    validationResult = null,
+                    nextRefreshJobInfo = null,
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "App Settings Content - Loading State")
+@Composable
+private fun PreviewAppSettingsContentLoading() {
+    TrmnlDisplayAppTheme {
+        AppSettingsContent(
+            state =
+                AppSettingsScreen.State(
+                    accessToken = "some-token",
+                    isLoading = true,
+                    validationResult = null,
+                    nextRefreshJobInfo = null,
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "App Settings Content - Validation Success")
+@Composable
+private fun PreviewAppSettingsContentSuccess() {
+    TrmnlDisplayAppTheme {
+        AppSettingsContent(
+            state =
+                AppSettingsScreen.State(
+                    accessToken = "valid-token-123",
+                    isLoading = false,
+                    validationResult =
+                        ValidationResult.Success(
+                            imageUrl = "https://example.com/image.png", // Placeholder URL
+                            refreshRateSecs = 3600,
+                        ),
+                    nextRefreshJobInfo = null,
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "App Settings Content - Validation Failure")
+@Composable
+private fun PreviewAppSettingsContentFailure() {
+    TrmnlDisplayAppTheme {
+        AppSettingsContent(
+            state =
+                AppSettingsScreen.State(
+                    accessToken = "invalid-token",
+                    isLoading = false,
+                    validationResult =
+                        ValidationResult.Failure(
+                            message = "Invalid access token provided. Please check and try again.",
+                        ),
+                    nextRefreshJobInfo = null,
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "App Settings Content - With Scheduled Work")
+@Composable
+private fun PreviewAppSettingsContentWithWork() {
+    val formatter = DateTimeFormatter.ofPattern("MMM dd 'at' hh:mm:ss a")
+    val nextRunTimeMillis = Instant.now().plusSeconds(15 * 60).toEpochMilli()
+    val nextRunTimeFormatted = Instant.ofEpochMilli(nextRunTimeMillis).atZone(ZoneId.systemDefault()).format(formatter)
+
+    TrmnlDisplayAppTheme {
+        AppSettingsContent(
+            state =
+                AppSettingsScreen.State(
+                    accessToken = "valid-token-123",
+                    isLoading = false,
+                    validationResult = null, // Can also be Success state
+                    nextRefreshJobInfo =
+                        NextImageRefreshDisplayInfo(
+                            workerState = WorkInfo.State.ENQUEUED,
+                            timeUntilNextRefresh = "in 15 minutes",
+                            nextRefreshOnDateTime = nextRunTimeFormatted,
+                            nextRefreshTimeMillis = nextRunTimeMillis,
+                        ),
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "Work Schedule Status Card - Scheduled")
+@Composable
+private fun PreviewWorkScheduleStatusCardScheduled() {
+    val formatter = DateTimeFormatter.ofPattern("MMM dd 'at' hh:mm:ss a")
+    val nextRunTimeMillis = Instant.now().plusSeconds(15 * 60).toEpochMilli()
+    val nextRunTimeFormatted = Instant.ofEpochMilli(nextRunTimeMillis).atZone(ZoneId.systemDefault()).format(formatter)
+
+    TrmnlDisplayAppTheme {
+        WorkScheduleStatusCard(
+            state =
+                AppSettingsScreen.State(
+                    accessToken = "some-token",
+                    nextRefreshJobInfo =
+                        NextImageRefreshDisplayInfo(
+                            workerState = WorkInfo.State.ENQUEUED,
+                            timeUntilNextRefresh = "in 15 minutes",
+                            nextRefreshOnDateTime = nextRunTimeFormatted,
+                            nextRefreshTimeMillis = nextRunTimeMillis,
+                        ),
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "Work Schedule Status Card - No Work")
+@Composable
+private fun PreviewWorkScheduleStatusCardNoWork() {
+    TrmnlDisplayAppTheme {
+        WorkScheduleStatusCard(
+            state =
+                AppSettingsScreen.State(
+                    accessToken = "some-token",
+                    nextRefreshJobInfo = null,
+                    eventSink = {},
+                ),
+        )
+    }
+}
+
+@Preview(name = "Fake API Info Banner")
+@Composable
+private fun PreviewFakeApiInfoBanner() {
+    TrmnlDisplayAppTheme {
+        FakeApiInfoBanner()
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance the `DisplayRefreshLogScreen` and `AppSettingsScreen` in the TRMNL app. The updates include renaming a key composable function for clarity, adding preview functions for better UI testing, and improving the visual design of components. Below is a categorized summary of the most important changes:

### Enhancements to `DisplayRefreshLogScreen`:

* Renamed the `LogItem` composable to `LogItemView` for better clarity and consistency. This change affects both the function definition and its usage in `DisplayRefreshLogContent`. [[1]](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0L254-R258) [[2]](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0L267-R271)
* Added multiple `@Preview` composable functions to provide visual previews of `DisplayRefreshLogContent` and `LogItemView` in different states, such as empty logs, success, and failure scenarios.

### Enhancements to `AppSettingsScreen`:

* Introduced `@Preview` composable functions for `AppSettingsContent` and related components, allowing developers to preview various states, including initial, loading, validation success, and failure scenarios.
* Updated the `FakeApiInfoBanner` composable to use `secondaryContainer` and `secondary` colors instead of `tertiaryContainer` and `tertiary`, aligning with the updated design guidelines. [[1]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L598-R603) [[2]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9L613-R618)

### Codebase Improvements:

* Added new imports for theme-related utilities (`TrmnlDisplayAppTheme`) and time formatting (`DateTimeFormatter`, `ZoneId`, `Instant`) to support the new preview functions and time-related features. [[1]](diffhunk://#diff-2a9f701ea0b57889302ea776afa6df43c4a5efcb753c83a0029be7dd652466e0R54-R58) [[2]](diffhunk://#diff-2365a2b154aa34e43b6b1143b24b82744be0611b08ea5092e47b377cd2cf42d9R95-R97)